### PR TITLE
IL-6175 Add Fuse whitelist metadata content (#320)

### DIFF
--- a/contracts/deploy/initialization/FuseMetadataTypes.sol
+++ b/contracts/deploy/initialization/FuseMetadataTypes.sol
@@ -1,37 +1,64 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-///@dev (0-unaudited,  1-reviewed, 2-tested, 3-audited)
-uint16 constant FUSE_METADATA_AUDIT_STATUS = 0;
-string constant FUSE_METADATA_AUDIT_STATUS_NAME = "Audit_Status";
-
-uint16 constant FUSE_METADATA_SUBSTRATE_INFO = 1;
-string constant FUSE_METADATA_SUBSTRATE_INFO_NAME = "Substrate_Info";
-
-///@dev (0-deposit, 1-balance, 2-dex, 3-perp, 4-borrow, 5-rewards)
-uint16 constant FUSE_METADATA_CATEGORY_INFO = 2;
-string constant FUSE_METADATA_CATEGORY_INFO_NAME = "Category_Info";
-
-///@dev (0-v1, 1-v2)
-uint16 constant FUSE_METADATA_ABI_VERSION = 3;
-string constant FUSE_METADATA_ABI_VERSION_NAME = "Abi_Version";
-
-///@dev (0-Aave, 1-Compound, 2-Curve, 3-Euler, 4-Fluid, 5-Gearbox, 6-Harvest, 7-Moonwell, 8-Morpho, 9-Ramses)
-uint16 constant FUSE_METADATA_PROTOCOL_INFO = 4;
-string constant FUSE_METADATA_PROTOCOL_INFO_NAME = "Protocol_Info";
 
 library FuseMetadataTypes {
-    function getAllFuseMetadataTypeIds() public pure returns (uint16[] memory) {
+
+    uint16 public constant FUSE_METADATA_AUDIT_STATUS_ID = 0;
+    string public constant FUSE_METADATA_AUDIT_STATUS_NAME = "AUDIT_STATUS";
+
+    string public constant FUSE_METADATA_AUDIT_STATUS_UNAUDITED_CODE = "UNAUDITED";
+    string public constant FUSE_METADATA_AUDIT_STATUS_REVIEWED_CODE = "REVIEWED";
+    string public constant FUSE_METADATA_AUDIT_STATUS_TESTED_CODE = "TESTED";
+    string public constant FUSE_METADATA_AUDIT_STATUS_AUDITED_CODE = "AUDITED";
+
+    uint16 public constant FUSE_METADATA_SUBSTRATE_INFO_ID = 1;
+    string public constant FUSE_METADATA_SUBSTRATE_INFO_NAME = "SUBSTRATE_INFO";
+
+    uint16 public constant FUSE_METADATA_CATEGORY_INFO_ID = 2;
+    string public constant FUSE_METADATA_CATEGORY_INFO_NAME = "CATEGORY_INFO";
+
+    string public constant FUSE_METADATA_CATEGORY_INFO_SUPPLY_CODE = "SUPPLY";
+    string public constant FUSE_METADATA_CATEGORY_INFO_BALANCE_CODE = "BALANCE";
+    string public constant FUSE_METADATA_CATEGORY_INFO_DEX_CODE = "DEX";
+    string public constant FUSE_METADATA_CATEGORY_INFO_PERPETUAL_CODE = "PERPETUAL";
+    string public constant FUSE_METADATA_CATEGORY_INFO_BORROW_CODE = "BORROW";
+    string public constant FUSE_METADATA_CATEGORY_INFO_REWARDS_CODE = "REWARDS";
+    string public constant FUSE_METADATA_CATEGORY_INFO_COLLATERAL_CODE = "COLLATERAL";
+    string public constant FUSE_METADATA_CATEGORY_INFO_FLASH_LOAN_CODE = "FLASH_LOAN";
+    string public constant FUSE_METADATA_CATEGORY_INFO_OTHER_CODE = "OTHER";
+
+    uint16 public constant FUSE_METADATA_ABI_VERSION_ID = 3;
+    string public constant FUSE_METADATA_ABI_VERSION_NAME = "ABI_VERSION";
+
+    string public constant FUSE_METADATA_ABI_VERSION_V1_CODE = "V1";
+    string public constant FUSE_METADATA_ABI_VERSION_V2_CODE = "V2";
+
+    uint16 public constant FUSE_METADATA_PROTOCOL_INFO_ID = 4;
+    string public constant FUSE_METADATA_PROTOCOL_INFO_NAME = "PROTOCOL_INFO";
+
+    string public constant FUSE_METADATA_PROTOCOL_INFO_AAVE_CODE = "AAVE";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_COMPOUND_CODE = "COMPOUND";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_CURVE_CODE = "CURVE";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_EULER_CODE = "EULER";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_FLUID_CODE = "FLUID";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_GEARBOX_CODE = "GEARBOX";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_HARVEST_CODE = "HARVEST";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_MOONWELL_CODE = "MOONWELL";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_MORPHO_CODE = "MORPHO";
+    string public constant FUSE_METADATA_PROTOCOL_INFO_RAMSES_CODE = "RAMSES";
+
+    function getAllFuseMetadataTypeIds() internal pure returns (uint16[] memory) {
         uint16[] memory fuseMetadataTypeIds = new uint16[](5);
-        fuseMetadataTypeIds[0] = FUSE_METADATA_AUDIT_STATUS;
-        fuseMetadataTypeIds[1] = FUSE_METADATA_SUBSTRATE_INFO;
-        fuseMetadataTypeIds[2] = FUSE_METADATA_CATEGORY_INFO;
-        fuseMetadataTypeIds[3] = FUSE_METADATA_ABI_VERSION;
-        fuseMetadataTypeIds[4] = FUSE_METADATA_PROTOCOL_INFO;
+        fuseMetadataTypeIds[0] = FUSE_METADATA_AUDIT_STATUS_ID;
+        fuseMetadataTypeIds[1] = FUSE_METADATA_SUBSTRATE_INFO_ID;
+        fuseMetadataTypeIds[2] = FUSE_METADATA_CATEGORY_INFO_ID;
+        fuseMetadataTypeIds[3] = FUSE_METADATA_ABI_VERSION_ID;
+        fuseMetadataTypeIds[4] = FUSE_METADATA_PROTOCOL_INFO_ID;
         return fuseMetadataTypeIds;
     }
 
-    function getAllFuseMetadataTypeNames() public pure returns (string[] memory) {
+    function getAllFuseMetadataTypeNames() internal pure returns (string[] memory) {
         string[] memory fuseMetadataTypeNames = new string[](5);
         fuseMetadataTypeNames[0] = FUSE_METADATA_AUDIT_STATUS_NAME;
         fuseMetadataTypeNames[1] = FUSE_METADATA_SUBSTRATE_INFO_NAME;
@@ -39,5 +66,25 @@ library FuseMetadataTypes {
         fuseMetadataTypeNames[3] = FUSE_METADATA_ABI_VERSION_NAME;
         fuseMetadataTypeNames[4] = FUSE_METADATA_PROTOCOL_INFO_NAME;
         return fuseMetadataTypeNames;
+    }
+
+    function stringToBytes32Array(string memory source) public pure returns (bytes32[] memory) {
+        bytes memory sourceBytes = bytes(source);
+        uint256 sourceLength = sourceBytes.length;
+        uint256 arrayLength = (sourceLength + 31) / 32;
+        bytes32[] memory result = new bytes32[](arrayLength);
+
+        for (uint256 i = 0; i < arrayLength; i++) {
+            bytes32 chunk;
+            for (uint256 j = 0; j < 32; j++) {
+                uint256 index = i * 32 + j;
+                if (index < sourceLength) {
+                    chunk |= bytes32(uint256(uint8(sourceBytes[index])) << (248 - j * 8));
+                }
+            }
+            result[i] = chunk;
+        }
+
+        return result;
     }
 }

--- a/contracts/deploy/initialization/FuseStatus.sol
+++ b/contracts/deploy/initialization/FuseStatus.sol
@@ -1,34 +1,35 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-/// @dev Default status after deployment
-uint16 constant FUSE_STATUS_DEFAULT = 0;
-string constant FUSE_STATUS_DEFAULT_NAME = "Default";
-
-/// @dev Fuse is active and can be used
-uint16 constant FUSE_STATUS_ACTIVE = 1;
-string constant FUSE_STATUS_ACTIVE_NAME = "Active";
-
-/// @dev Fuse is deprecated and should not be used
-uint16 constant FUSE_STATUS_DEPRECATED = 2;
-string constant FUSE_STATUS_DEPRECATED_NAME = "Deprecated";
-
-/// @dev Fuse is removed and should not be used
-uint16 constant FUSE_STATUS_REMOVED = 3;
-string constant FUSE_STATUS_REMOVED_NAME = "Removed";
-
 /// @dev Returns all fuse statuses
 library FuseStatus {
-    function getAllFuseStatuIds() public pure returns (uint16[] memory) {
+
+    /// @dev Default status after deployment
+    uint16 public constant FUSE_STATUS_DEFAULT_ID = 0;
+    string public constant FUSE_STATUS_DEFAULT_NAME = "DEFAULT";
+
+    /// @dev Fuse is active and can be used
+    uint16 public constant FUSE_STATUS_ACTIVE_ID = 1;
+    string public constant FUSE_STATUS_ACTIVE_NAME = "ACTIVE";
+
+    /// @dev Fuse is deprecated and should not be used
+    uint16 public constant FUSE_STATUS_DEPRECATED_ID = 2;
+    string public constant FUSE_STATUS_DEPRECATED_NAME = "DEPRECATED";
+
+    /// @dev Fuse is removed and should not be used
+    uint16 public constant FUSE_STATUS_REMOVED_ID = 3;
+    string public constant FUSE_STATUS_REMOVED_NAME = "REMOVED";
+
+    function getAllFuseStatuIds() internal pure returns (uint16[] memory) {
         uint16[] memory fuseStatuses = new uint16[](4);
-        fuseStatuses[0] = FUSE_STATUS_DEFAULT;
-        fuseStatuses[1] = FUSE_STATUS_ACTIVE;
-        fuseStatuses[2] = FUSE_STATUS_DEPRECATED;
-        fuseStatuses[3] = FUSE_STATUS_REMOVED;
+        fuseStatuses[0] = FUSE_STATUS_DEFAULT_ID;
+        fuseStatuses[1] = FUSE_STATUS_ACTIVE_ID;
+        fuseStatuses[2] = FUSE_STATUS_DEPRECATED_ID;
+        fuseStatuses[3] = FUSE_STATUS_REMOVED_ID;
         return fuseStatuses;
     }
 
-    function getAllFuseStatusNames() public pure returns (string[] memory) {
+    function getAllFuseStatusNames() internal pure returns (string[] memory) {
         string[] memory fuseStatusNames = new string[](4);
         fuseStatusNames[0] = FUSE_STATUS_DEFAULT_NAME;
         fuseStatusNames[1] = FUSE_STATUS_ACTIVE_NAME;

--- a/contracts/deploy/initialization/FuseTypes.sol
+++ b/contracts/deploy/initialization/FuseTypes.sol
@@ -1,217 +1,338 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.26;
 
-uint16 constant AAVEV2_BALANCE_FUSE_ID = 1;
-string constant AAVEV2_BALANCE_FUSE_NAME = "AaveV2_Balance_Fuse";
-
-uint16 constant AAVEV2_SUPPLY_FUSE_ID = 2;
-string constant AAVEV2_SUPPLY_FUSE_NAME = "AaveV2_Supply_Fuse";
-
-uint16 constant AAVEV3_BALANCE_FUSE_ID = 3;
-string constant AAVEV3_BALANCE_FUSE_NAME = "AaveV3_Balance_Fuse";
-
-uint16 constant AAVEV3_SUPPLY_FUSE_ID = 4;
-string constant AAVEV3_SUPPLY_FUSE_NAME = "AaveV3_Supply_Fuse";
-
-uint16 constant AAVEV3_BORROW_FUSE_ID = 5;
-string constant AAVEV3_BORROW_FUSE_NAME = "AaveV3_Borrow_Fuse";
-
-uint16 constant BURN_REQUEST_FEE_FUSE_ID = 6;
-string constant BURN_REQUEST_FEE_FUSE_NAME = "Burn_Request_Fee_Fuse";
-
-uint16 constant SPARK_BALANCE_FUSE_ID = 7;
-string constant SPARK_BALANCE_FUSE_NAME = "Spark_Balance_Fuse";
-
-uint16 constant SPARK_SUPPLY_FUSE_ID = 8;
-string constant SPARK_SUPPLY_FUSE_NAME = "Spark_Supply_Fuse";
-
-uint16 constant COMPOUNDV2_BALANCE_FUSE_ID = 9;
-string constant COMPOUNDV2_BALANCE_FUSE_NAME = "CompoundV2_Balance_Fuse";
-
-uint16 constant COMPOUNDV2_SUPPLY_FUSE_ID = 10;
-string constant COMPOUNDV2_SUPPLY_FUSE_NAME = "CompoundV2_Supply_Fuse";
-
-uint16 constant COMPOUNDV3_BALANCE_FUSE_ID = 11;
-string constant COMPOUNDV3_BALANCE_FUSE_NAME = "CompoundV3_Balance_Fuse";
-
-uint16 constant COMPOUNDV3_SUPPLY_FUSE_ID = 12;
-string constant COMPOUNDV3_SUPPLY_FUSE_NAME = "CompoundV3_Supply_Fuse";
-
-uint16 constant COMPOUNDV3_CLAIM_FUSE_ID = 13;
-string constant COMPOUNDV3_CLAIM_FUSE_NAME = "CompoundV3_Claim_Fuse";
-
-uint16 constant CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE_ID = 14;
-string constant CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE_NAME = "Curve_Child_Liquidity_Gauge_Balance_Fuse";
-
-uint16 constant CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE_ID = 15;
-string constant CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE_NAME = "Curve_Child_Liquidity_Gauge_Supply_Fuse";
-
-uint16 constant CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE_ID = 16;
-string constant CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE_NAME = "Curve_Child_Liquidity_Gauge_Erc4626_Balance_Fuse";
-
-uint16 constant CURVE_STABLESWAP_NG_SINGLE_SIDE_BALANCE_FUSE_ID = 17;
-string constant CURVE_STABLESWAP_NG_SINGLE_SIDE_BALANCE_FUSE_NAME = "Curve_Stableswap_NG_Single_Side_Balance_Fuse";
-
-uint16 constant CURVE_STABLESWAP_NG_SINGLE_SIDE_SUPPLY_FUSE_ID = 18;
-string constant CURVE_STABLESWAP_NG_SINGLE_SIDE_SUPPLY_FUSE_NAME = "Curve_Stableswap_NG_Single_Side_Supply_Fuse";
-
-uint16 constant CURVE_GAUGE_TOKEN_CLAIM_FUSE_ID = 19;
-string constant CURVE_GAUGE_TOKEN_CLAIM_FUSE_NAME = "Curve_Gauge_Token_Claim_Fuse";
-
-uint16 constant ERC20_BALANCE_FUSE_ID = 20;
-string constant ERC20_BALANCE_FUSE_NAME = "ERC20_Balance_Fuse";
-
-uint16 constant ERC4626_BALANCE_FUSE_ID = 21;
-string constant ERC4626_BALANCE_FUSE_NAME = "Erc4626_Balance_Fuse";
-
-uint16 constant ERC4626_SUPPLY_FUSE_ID = 22;
-string constant ERC4626_SUPPLY_FUSE_NAME = "Erc4626_Supply_Fuse";
-
-uint16 constant EULERV2_BALANCE_FUSE_ID = 23;
-string constant EULERV2_BALANCE_FUSE_NAME = "EulerV2_Balance_Fuse";
-
-uint16 constant EULERV2_SUPPLY_FUSE_ID = 24;
-string constant EULERV2_SUPPLY_FUSE_NAME = "EulerV2_Supply_Fuse";
-
-uint16 constant EULERV2_BORROW_FUSE_ID = 25;
-string constant EULERV2_BORROW_FUSE_NAME = "EulerV2_Borrow_Fuse";
-
-uint16 constant EULERV2_COLLATERAL_FUSE_ID = 26;
-string constant EULERV2_COLLATERAL_FUSE_NAME = "EulerV2_Collateral_Fuse";
-
-uint16 constant EULERV2_CONTROLLER_FUSE_ID = 27;
-string constant EULERV2_CONTROLLER_FUSE_NAME = "EulerV2_Controller_Fuse";
-
-uint16 constant FLUID_INSTADAPP_STAKING_BALANCE_FUSE_ID = 28;
-string constant FLUID_INSTADAPP_STAKING_BALANCE_FUSE_NAME = "Fluid_Instadapp_Staking_Balance_Fuse";
-
-uint16 constant FLUID_INSTADAPP_STAKING_SUPPLY_FUSE_ID = 29;
-string constant FLUID_INSTADAPP_STAKING_SUPPLY_FUSE_NAME = "Fluid_Instadapp_Staking_Supply_Fuse";
-
-uint16 constant FLUID_INSTADAPP_CLAIM_FUSE_ID = 30;
-string constant FLUID_INSTADAPP_CLAIM_FUSE_NAME = "Fluid_Instadapp_Claim_Fuse";
-
-uint16 constant FLUID_PROOF_CLAIM_FUSE_ID = 31;
-string constant FLUID_PROOF_CLAIM_FUSE_NAME = "Fluid_Proof_Claim_Fuse";
-
-uint16 constant GEARBOXV3_FARM_BALANCE_FUSE_ID = 32;
-string constant GEARBOXV3_FARM_BALANCE_FUSE_NAME = "GearboxV3_Farm_Balance_Fuse";
-
-uint16 constant GEARBOXV3_FARM_SUPPLY_FUSE_ID = 33;
-string constant GEARBOXV3_FARM_SUPPLY_FUSE_NAME = "GearboxV3_Farm_Supply_Fuse";
-
-uint16 constant GEARBOXV3_FARM_D_TOKEN_CLAIM_FUSE_ID = 34;
-string constant GEARBOXV3_FARM_D_TOKEN_CLAIM_FUSE_NAME = "GearboxV3_Farm_D_Token_Claim_Fuse";
-
-uint16 constant HARVEST_DO_HARD_WORK_FUSE_ID = 35;
-string constant HARVEST_DO_HARD_WORK_FUSE_NAME = "Harvest_Do_Hard_Work_Fuse";
-
-uint16 constant MOONWELL_BALANCE_FUSE_ID = 36;
-string constant MOONWELL_BALANCE_FUSE_NAME = "Moonwell_Balance_Fuse";
-
-uint16 constant MOONWELL_SUPPLY_FUSE_ID = 37;
-string constant MOONWELL_SUPPLY_FUSE_NAME = "Moonwell_Supply_Fuse";
-
-uint16 constant MOONWELL_BORROW_FUSE_ID = 38;
-string constant MOONWELL_BORROW_FUSE_NAME = "Moonwell_Borrow_Fuse";
-
-uint16 constant MOONWELL_ENABLE_MARKET_FUSE_ID = 39;
-string constant MOONWELL_ENABLE_MARKET_FUSE_NAME = "Moonwell_Enable_Market_Fuse";
-
-uint16 constant MOONWELL_CLAIM_FUSE_ID = 40;
-string constant MOONWELL_CLAIM_FUSE_NAME = "Moonwell_Claim_Fuse";
-
-uint16 constant MORPHO_BALANCE_FUSE_ID = 41;
-string constant MORPHO_BALANCE_FUSE_NAME = "Morpho_Balance_Fuse";
-
-uint16 constant MORPHO_BORROW_FUSE_ID = 42;
-string constant MORPHO_BORROW_FUSE_NAME = "Morpho_Borrow_Fuse";
-
-uint16 constant MORPHO_COLLATERAL_FUSE_ID = 43;
-string constant MORPHO_COLLATERAL_FUSE_NAME = "Morpho_Collateral_Fuse";
-
-uint16 constant MORPHO_FLASH_LOAN_FUSE_ID = 44;
-string constant MORPHO_FLASH_LOAN_FUSE_NAME = "Morpho_Flash_Loan_Fuse";
-
-uint16 constant MORPHO_SUPPLY_FUSE_ID = 45;
-string constant MORPHO_SUPPLY_FUSE_NAME = "Morpho_Supply_Fuse";
-
-uint16 constant MORPHO_SUPPLY_WITH_CALLBACK_DATA_FUSE_ID = 46;
-string constant MORPHO_SUPPLY_WITH_CALLBACK_DATA_FUSE_NAME = "Morpho_Supply_With_Callback_Data_Fuse";
-
-uint16 constant MORPHO_CLAIM_FUSE_ID = 47;
-string constant MORPHO_CLAIM_FUSE_NAME = "Morpho_Claim_Fuse";
-
-uint16 constant PENDLE_REDEEM_PT_AFTER_MATURITY_FUSE_ID = 48;
-string constant PENDLE_REDEEM_PT_AFTER_MATURITY_FUSE_NAME = "Pendle_Redeem_PT_After_Maturity_Fuse";
-
-uint16 constant PENDLE_SWAP_PT_FUSE_ID = 49;
-string constant PENDLE_SWAP_PT_FUSE_NAME = "Pendle_Swap_PT_Fuse";
-
-uint16 constant PLASMA_VAULT_REQUEST_SHARES_FUSE_ID = 50;
-string constant PLASMA_VAULT_REQUEST_SHARES_FUSE_NAME = "Plasma_Vault_Request_Shares_Fuse";
-
-uint16 constant PLASMA_VAULT_REDEEM_FROM_REQUEST_FUSE_ID = 51;
-string constant PLASMA_VAULT_REDEEM_FROM_REQUEST_FUSE_NAME = "Plasma_Vault_Redeem_From_Request_Fuse";
-
-uint16 constant RAMSES_V2_BALANCE_FUSE_ID = 52;
-string constant RAMSES_V2_BALANCE_FUSE_NAME = "Ramses_V2_Balance_Fuse";
-
-uint16 constant RAMSES_V2_COLLECT_FUSE_ID = 53;
-string constant RAMSES_V2_COLLECT_FUSE_NAME = "Ramses_V2_Collect_Fuse";
-
-uint16 constant RAMSES_V2_MODIFY_POSITION_FUSE_ID = 54;
-string constant RAMSES_V2_MODIFY_POSITION_FUSE_NAME = "Ramses_V2_Modify_Position_Fuse";
-
-uint16 constant RAMSES_V2_NEW_POSITION_FUSE_ID = 55;
-string constant RAMSES_V2_NEW_POSITION_FUSE_NAME = "Ramses_V2_New_Position_Fuse";
-
-uint16 constant RAMSES_CLAIM_FUSE_ID = 56;
-string constant RAMSES_CLAIM_FUSE_NAME = "Ramses_Claim_Fuse";
-
-uint16 constant UNISWAP_V2_SWAP_FUSE_ID = 57;
-string constant UNISWAP_V2_SWAP_FUSE_NAME = "Uniswap_V2_Swap_Fuse";
-
-uint16 constant UNISWAP_V3_BALANCE_FUSE_ID = 58;
-string constant UNISWAP_V3_BALANCE_FUSE_NAME = "Uniswap_V3_Balance_Fuse";
-
-uint16 constant UNISWAP_V3_COLLECT_FUSE_ID = 59;
-string constant UNISWAP_V3_COLLECT_FUSE_NAME = "Uniswap_V3_Collect_Fuse";
-
-uint16 constant UNISWAP_V3_MODIFY_POSITION_FUSE_ID = 60;
-string constant UNISWAP_V3_MODIFY_POSITION_FUSE_NAME = "Uniswap_V3_Modify_Position_Fuse";
-
-uint16 constant UNISWAP_V3_NEW_POSITION_FUSE_ID = 61;
-string constant UNISWAP_V3_NEW_POSITION_FUSE_NAME = "Uniswap_V3_New_Position_Fuse";
-
-uint16 constant UNISWAP_V3_SWAP_FUSE_ID = 62;
-string constant UNISWAP_V3_SWAP_FUSE_NAME = "Uniswap_V3_Swap_Fuse";
-
-uint16 constant UNIVERSAL_TOKEN_SWAPPER_FUSE_ID = 63;
-string constant UNIVERSAL_TOKEN_SWAPPER_FUSE_NAME = "Universal_Token_Swapper_Fuse";
-
-uint16 constant UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE_ID = 64;
-string constant UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE_NAME = "Universal_Token_Swapper_Eth_Fuse";
-
-uint16 constant UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE_ID = 65;
-string constant UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE_NAME = "Universal_Token_Swapper_With_Verification_Fuse";
-
 library FuseTypes {
-    function getAllFuseId() internal pure returns (uint16[] memory) {
-        uint16[] memory fuseIds = new uint16[](65);
-        fuseIds[0] = AAVEV2_BALANCE_FUSE_ID;
-        fuseIds[1] = AAVEV2_SUPPLY_FUSE_ID;
-        fuseIds[2] = AAVEV3_BALANCE_FUSE_ID;
-        fuseIds[3] = AAVEV3_SUPPLY_FUSE_ID;
-        fuseIds[4] = AAVEV3_BORROW_FUSE_ID;
+
+    uint16 public constant AAVE_V2_BALANCE_FUSE_ID = 1;
+    string public constant AAVE_V2_BALANCE_FUSE_NAME = "AAVE_V2_BALANCE_FUSE";
+
+    uint16 public constant AAVE_V2_SUPPLY_FUSE_ID = 2;
+    string public constant AAVE_V2_SUPPLY_FUSE_NAME = "AAVE_V2_SUPPLY_FUSE";
+
+    uint16 public constant AAVE_V3_BALANCE_FUSE_ID = 3;
+    string public constant AAVE_V3_BALANCE_FUSE_NAME = "AAVE_V3_BALANCE_FUSE";
+
+    uint16 public constant AAVE_V3_SUPPLY_FUSE_ID = 4;
+    string public constant AAVE_V3_SUPPLY_FUSE_NAME = "AAVE_V3_SUPPLY_FUSE";
+
+    uint16 public constant AAVE_V3_BORROW_FUSE_ID = 5;
+    string public constant AAVE_V3_BORROW_FUSE_NAME = "AAVE_V3_BORROW_FUSE";
+
+    uint16 public constant BURN_REQUEST_FEE_FUSE_ID = 6;
+    string public constant BURN_REQUEST_FEE_FUSE_NAME = "BURN_REQUEST_FEE_FUSE";
+
+    uint16 public constant SPARK_BALANCE_FUSE_ID = 7;
+    string public constant SPARK_BALANCE_FUSE_NAME = "SPARK_BALANCE_FUSE";
+
+    uint16 public constant SPARK_SUPPLY_FUSE_ID = 8;
+    string public constant SPARK_SUPPLY_FUSE_NAME = "SPARK_SUPPLY_FUSE";
+
+    uint16 public constant COMPOUND_V2_BALANCE_FUSE_ID = 9;
+    string public constant COMPOUND_V2_BALANCE_FUSE_NAME = "COMPOUND_V2_BALANCE_FUSE";
+
+    uint16 public constant COMPOUND_V2_SUPPLY_FUSE_ID = 10;
+    string public constant COMPOUND_V2_SUPPLY_FUSE_NAME = "COMPOUND_V2_SUPPLY_FUSE";
+
+    uint16 public constant COMPOUND_V3_BALANCE_FUSE_ID = 11;
+    string public constant COMPOUND_V3_BALANCE_FUSE_NAME = "COMPOUND_V3_BALANCE_FUSE";
+
+    uint16 public constant COMPOUND_V3_SUPPLY_FUSE_ID = 12;
+    string public constant COMPOUND_V3_SUPPLY_FUSE_NAME = "COMPOUND_V3_SUPPLY_FUSE";
+
+    uint16 public constant COMPOUND_V3_CLAIM_FUSE_ID = 13;
+    string public constant COMPOUND_V3_CLAIM_FUSE_NAME = "COMPOUND_V3_CLAIM_FUSE";
+
+    uint16 public constant CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE_ID = 14;
+    string public constant CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE_NAME = "CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE";
+
+    uint16 public constant CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE_ID = 15;
+    string public constant CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE_NAME = "CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE";
+
+    uint16 public constant CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE_ID = 16;
+    string public constant CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE_NAME = "CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE";
+
+    uint16 public constant CURVE_STABLESWAP_NG_SINGLE_SIDE_BALANCE_FUSE_ID = 17;
+    string public constant CURVE_STABLESWAP_NG_SINGLE_SIDE_BALANCE_FUSE_NAME = "CURVE_STABLESWAP_NG_SINGLE_SIDE_BALANCE_FUSE";
+
+    uint16 public constant CURVE_STABLESWAP_NG_SINGLE_SIDE_SUPPLY_FUSE_ID = 18;
+    string public constant CURVE_STABLESWAP_NG_SINGLE_SIDE_SUPPLY_FUSE_NAME = "CURVE_STABLESWAP_NG_SINGLE_SIDE_SUPPLY_FUSE";
+
+    uint16 public constant CURVE_GAUGE_TOKEN_CLAIM_FUSE_ID = 19;
+    string public constant CURVE_GAUGE_TOKEN_CLAIM_FUSE_NAME = "CURVE_GAUGE_TOKEN_CLAIM_FUSE";
+
+    uint16 public constant ERC20_BALANCE_FUSE_ID = 20;
+    string public constant ERC20_BALANCE_FUSE_NAME = "ERC20_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_BALANCE_FUSE_ID = 21;
+    string public constant ERC4626_BALANCE_FUSE_NAME = "ERC4626_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_SUPPLY_FUSE_ID = 22;
+    string public constant ERC4626_SUPPLY_FUSE_NAME = "ERC4626_SUPPLY_FUSE";
+
+    uint16 public constant EULER_V2_BALANCE_FUSE_ID = 23;
+    string public constant EULER_V2_BALANCE_FUSE_NAME = "EULER_V2_BALANCE_FUSE";
+
+    uint16 public constant EULER_V2_SUPPLY_FUSE_ID = 24;
+    string public constant EULER_V2_SUPPLY_FUSE_NAME = "EULER_V2_SUPPLY_FUSE";
+
+    uint16 public constant EULER_V2_BORROW_FUSE_ID = 25;
+    string public constant EULER_V2_BORROW_FUSE_NAME = "EULER_V2_BORROW_FUSE";
+
+    uint16 public constant EULER_V2_COLLATERAL_FUSE_ID = 26;
+    string public constant EULER_V2_COLLATERAL_FUSE_NAME = "EULER_V2_COLLATERAL_FUSE";
+
+    uint16 public constant EULER_V2_CONTROLLER_FUSE_ID = 27;
+    string public constant EULER_V2_CONTROLLER_FUSE_NAME = "EULER_V2_CONTROLLER_FUSE";
+
+    uint16 public constant FLUID_INSTADAPP_STAKING_BALANCE_FUSE_ID = 28;
+    string public constant FLUID_INSTADAPP_STAKING_BALANCE_FUSE_NAME = "FLUID_INSTADAPP_STAKING_BALANCE_FUSE";
+
+    uint16 public constant FLUID_INSTADAPP_STAKING_SUPPLY_FUSE_ID = 29;
+    string public constant FLUID_INSTADAPP_STAKING_SUPPLY_FUSE_NAME = "FLUID_INSTADAPP_STAKING_SUPPLY_FUSE";
+
+    uint16 public constant FLUID_INSTADAPP_CLAIM_FUSE_ID = 30;
+    string public constant FLUID_INSTADAPP_CLAIM_FUSE_NAME = "FLUID_INSTADAPP_CLAIM_FUSE";
+
+    uint16 public constant FLUID_PROOF_CLAIM_FUSE_ID = 31;
+    string public constant FLUID_PROOF_CLAIM_FUSE_NAME = "FLUID_PROOF_CLAIM_FUSE";
+
+    uint16 public constant GEARBOX_V3_FARM_BALANCE_FUSE_ID = 32;
+    string public constant GEARBOX_V3_FARM_BALANCE_FUSE_NAME = "GEARBOX_V3_FARM_BALANCE_FUSE";
+
+    uint16 public constant GEARBOX_V3_FARM_SUPPLY_FUSE_ID = 33;
+    string public constant GEARBOX_V3_FARM_SUPPLY_FUSE_NAME = "GEARBOX_V3_FARM_SUPPLY_FUSE";
+
+    uint16 public constant GEARBOX_V3_FARM_D_TOKEN_CLAIM_FUSE_ID = 34;
+    string public constant GEARBOX_V3_FARM_D_TOKEN_CLAIM_FUSE_NAME = "GEARBOX_V3_FARM_D_TOKEN_CLAIM_FUSE";
+
+    uint16 public constant HARVEST_DO_HARD_WORK_FUSE_ID = 35;
+    string public constant HARVEST_DO_HARD_WORK_FUSE_NAME = "HARVEST_DO_HARD_WORK_FUSE";
+
+    uint16 public constant MOONWELL_BALANCE_FUSE_ID = 36;
+    string public constant MOONWELL_BALANCE_FUSE_NAME = "MOONWELL_BALANCE_FUSE";
+
+    uint16 public constant MOONWELL_SUPPLY_FUSE_ID = 37;
+    string public constant MOONWELL_SUPPLY_FUSE_NAME = "MOONWELL_SUPPLY_FUSE";
+
+    uint16 public constant MOONWELL_BORROW_FUSE_ID = 38;
+    string public constant MOONWELL_BORROW_FUSE_NAME = "MOONWELL_BORROW_FUSE";
+
+    uint16 public constant MOONWELL_ENABLE_MARKET_FUSE_ID = 39;
+    string public constant MOONWELL_ENABLE_MARKET_FUSE_NAME = "MOONWELL_ENABLE_MARKET_FUSE";
+
+    uint16 public constant MOONWELL_CLAIM_FUSE_ID = 40;
+    string public constant MOONWELL_CLAIM_FUSE_NAME = "MOONWELL_CLAIM_FUSE";
+
+    uint16 public constant MORPHO_BALANCE_FUSE_ID = 41;
+    string public constant MORPHO_BALANCE_FUSE_NAME = "MORPHO_BALANCE_FUSE";
+
+    uint16 public constant MORPHO_BORROW_FUSE_ID = 42;
+    string public constant MORPHO_BORROW_FUSE_NAME = "MORPHO_BORROW_FUSE";
+
+    uint16 public constant MORPHO_COLLATERAL_FUSE_ID = 43;
+    string public constant MORPHO_COLLATERAL_FUSE_NAME = "MORPHO_COLLATERAL_FUSE";
+
+    uint16 public constant MORPHO_FLASH_LOAN_FUSE_ID = 44;
+    string public constant MORPHO_FLASH_LOAN_FUSE_NAME = "MORPHO_FLASH_LOAN_FUSE";
+
+    uint16 public constant MORPHO_SUPPLY_FUSE_ID = 45;
+    string public constant MORPHO_SUPPLY_FUSE_NAME = "MORPHO_SUPPLY_FUSE";
+
+    uint16 public constant MORPHO_SUPPLY_WITH_CALLBACK_DATA_FUSE_ID = 46;
+    string public constant MORPHO_SUPPLY_WITH_CALLBACK_DATA_FUSE_NAME = "MORPHO_SUPPLY_WITH_CALLBACK_DATA_FUSE";
+
+    uint16 public constant MORPHO_CLAIM_FUSE_ID = 47;
+    string public constant MORPHO_CLAIM_FUSE_NAME = "MORPHO_CLAIM_FUSE";
+
+    uint16 public constant PENDLE_REDEEM_PT_AFTER_MATURITY_FUSE_ID = 48;
+    string public constant PENDLE_REDEEM_PT_AFTER_MATURITY_FUSE_NAME = "PENDLE_REDEEM_PT_AFTER_MATURITY_FUSE";
+
+    uint16 public constant PENDLE_SWAP_PT_FUSE_ID = 49;
+    string public constant PENDLE_SWAP_PT_FUSE_NAME = "PENDLE_SWAP_PT_FUSE";
+
+    uint16 public constant PLASMA_VAULT_REQUEST_SHARES_FUSE_ID = 50;
+    string public constant PLASMA_VAULT_REQUEST_SHARES_FUSE_NAME = "PLASMA_VAULT_REQUEST_SHARES_FUSE";
+
+    uint16 public constant PLASMA_VAULT_REDEEM_FROM_REQUEST_FUSE_ID = 51;
+    string public constant PLASMA_VAULT_REDEEM_FROM_REQUEST_FUSE_NAME = "PLASMA_VAULT_REDEEM_FROM_REQUEST_FUSE";
+
+    uint16 public constant RAMSES_V2_BALANCE_FUSE_ID = 52;
+    string public constant RAMSES_V2_BALANCE_FUSE_NAME = "RAMSES_V2_BALANCE_FUSE";
+
+    uint16 public constant RAMSES_V2_COLLECT_FUSE_ID = 53;
+    string public constant RAMSES_V2_COLLECT_FUSE_NAME = "RAMSES_V2_COLLECT_FUSE";
+
+    uint16 public constant RAMSES_V2_MODIFY_POSITION_FUSE_ID = 54;
+    string public constant RAMSES_V2_MODIFY_POSITION_FUSE_NAME = "RAMSES_V2_MODIFY_POSITION_FUSE";
+
+    uint16 public constant RAMSES_V2_NEW_POSITION_FUSE_ID = 55;
+    string public constant RAMSES_V2_NEW_POSITION_FUSE_NAME = "RAMSES_V2_NEW_POSITION_FUSE";
+
+    uint16 public constant RAMSES_CLAIM_FUSE_ID = 56;
+    string public constant RAMSES_CLAIM_FUSE_NAME = "RAMSES_CLAIM_FUSE";
+
+    uint16 public constant UNISWAP_V2_SWAP_FUSE_ID = 57;
+    string public constant UNISWAP_V2_SWAP_FUSE_NAME = "UNISWAP_V2_SWAP_FUSE";
+
+    uint16 public constant UNISWAP_V3_BALANCE_FUSE_ID = 58;
+    string public constant UNISWAP_V3_BALANCE_FUSE_NAME = "UNISWAP_V3_BALANCE_FUSE";
+
+    uint16 public constant UNISWAP_V3_COLLECT_FUSE_ID = 59;
+    string public constant UNISWAP_V3_COLLECT_FUSE_NAME = "UNISWAP_V3_COLLECT_FUSE";
+
+    uint16 public constant UNISWAP_V3_MODIFY_POSITION_FUSE_ID = 60;
+    string public constant UNISWAP_V3_MODIFY_POSITION_FUSE_NAME = "UNISWAP_V3_MODIFY_POSITION_FUSE";
+
+    uint16 public constant UNISWAP_V3_NEW_POSITION_FUSE_ID = 61;
+    string public constant UNISWAP_V3_NEW_POSITION_FUSE_NAME = "UNISWAP_V3_NEW_POSITION_FUSE";
+
+    uint16 public constant UNISWAP_V3_SWAP_FUSE_ID = 62;
+    string public constant UNISWAP_V3_SWAP_FUSE_NAME = "UNISWAP_V3_SWAP_FUSE";
+
+    uint16 public constant UNIVERSAL_TOKEN_SWAPPER_FUSE_ID = 63;
+    string public constant UNIVERSAL_TOKEN_SWAPPER_FUSE_NAME = "UNIVERSAL_TOKEN_SWAPPER_FUSE";
+
+    uint16 public constant UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE_ID = 64;
+    string public constant UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE_NAME = "UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE";
+
+    uint16 public constant UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE_ID = 65;
+    string public constant UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE_NAME = "UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE";
+
+    uint16 public constant AAVE_V3_WITH_PRICE_ORACLE_BALANCE_FUSE_ID = 66;
+    string public constant AAVE_V3_WITH_PRICE_ORACLE_BALANCE_FUSE_NAME = "AAVE_V3_WITH_PRICE_ORACLE_BALANCE_FUSE";
+
+    uint16 public constant FLUID_INSTADAPP_POOL_SUPPLY_FUSE_ID = 67;
+    string public constant FLUID_INSTADAPP_POOL_SUPPLY_FUSE_NAME = "FLUID_INSTADAPP_POOL_SUPPLY_FUSE";
+
+    uint16 public constant FLUID_INSTADAPP_POOL_BALANCE_FUSE_ID = 68;
+    string public constant FLUID_INSTADAPP_POOL_BALANCE_FUSE_NAME = "FLUID_INSTADAPP_POOL_BALANCE_FUSE";
+
+    uint16 public constant PENDLE_BALANCE_FUSE_ID = 69;
+    string public constant PENDLE_BALANCE_FUSE_NAME = "PENDLE_BALANCE_FUSE";
+
+    uint16 public constant UNIVERSAL_READER_BALANCE_FUSE_ID = 70;
+    string public constant UNIVERSAL_READER_BALANCE_FUSE_NAME = "UNIVERSAL_READER_BALANCE_FUSE";
+
+    uint16 public constant META_MORPHO_MARKET_0001_SUPPLY_FUSE_ID = 71;
+    string public constant META_MORPHO_MARKET_0001_SUPPLY_FUSE_NAME = "META_MORPHO_MARKET_0001_SUPPLY_FUSE";
+
+    uint16 public constant META_MORPHO_MARKET_0001_BALANCE_FUSE_ID = 72;
+    string public constant META_MORPHO_MARKET_0001_BALANCE_FUSE_NAME = "META_MORPHO_MARKET_0001_BALANCE_FUSE";
+
+    uint16 public constant UNISWAP_V3_SWAP_POSITIONS_BALANCE_FUSE_ID = 73;
+    string public constant UNISWAP_V3_SWAP_POSITIONS_BALANCE_FUSE_NAME = "UNISWAP_V3_SWAP_POSITIONS_BALANCE_FUSE";
+
+    uint16 public constant COMPOUND_V3_USDC_BALANCE_FUSE_ID = 74;
+    string public constant COMPOUND_V3_USDC_BALANCE_FUSE_NAME = "COMPOUND_V3_USDC_BALANCE_FUSE";
+
+    uint16 public constant COMPOUND_V3_WETH_BALANCE_FUSE_ID = 75;
+    string public constant COMPOUND_V3_WETH_BALANCE_FUSE_NAME = "COMPOUND_V3_WETH_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_1_BALANCE_FUSE_ID = 76;
+    string public constant ERC4626_MARKET_1_BALANCE_FUSE_NAME = "ERC4626_MARKET_1_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_2_BALANCE_FUSE_ID = 77;
+    string public constant ERC4626_MARKET_2_BALANCE_FUSE_NAME = "ERC4626_MARKET_2_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_3_BALANCE_FUSE_ID = 78;
+    string public constant ERC4626_MARKET_3_BALANCE_FUSE_NAME = "ERC4626_MARKET_3_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_4_BALANCE_FUSE_ID = 79;
+    string public constant ERC4626_MARKET_4_BALANCE_FUSE_NAME = "ERC4626_MARKET_4_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_5_BALANCE_FUSE_ID = 80;
+    string public constant ERC4626_MARKET_5_BALANCE_FUSE_NAME = "ERC4626_MARKET_5_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_6_BALANCE_FUSE_ID = 81;
+    string public constant ERC4626_MARKET_6_BALANCE_FUSE_NAME = "ERC4626_MARKET_6_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_7_BALANCE_FUSE_ID = 82;
+    string public constant ERC4626_MARKET_7_BALANCE_FUSE_NAME = "ERC4626_MARKET_7_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_8_BALANCE_FUSE_ID = 83;
+    string public constant ERC4626_MARKET_8_BALANCE_FUSE_NAME = "ERC4626_MARKET_8_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_9_BALANCE_FUSE_ID = 84;
+    string public constant ERC4626_MARKET_9_BALANCE_FUSE_NAME = "ERC4626_MARKET_9_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_10_BALANCE_FUSE_ID = 85;
+    string public constant ERC4626_MARKET_10_BALANCE_FUSE_NAME = "ERC4626_MARKET_10_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_11_BALANCE_FUSE_ID = 86;
+    string public constant ERC4626_MARKET_11_BALANCE_FUSE_NAME = "ERC4626_MARKET_11_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_12_BALANCE_FUSE_ID = 87;
+    string public constant ERC4626_MARKET_12_BALANCE_FUSE_NAME = "ERC4626_MARKET_12_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_13_BALANCE_FUSE_ID = 88;
+    string public constant ERC4626_MARKET_13_BALANCE_FUSE_NAME = "ERC4626_MARKET_13_BALANCE_FUSE";
+
+    uint16 public constant ERC4626_MARKET_14_BALANCE_FUSE_ID = 89;
+    string public constant ERC4626_MARKET_14_BALANCE_FUSE_NAME = "ERC4626_MARKET_14_BALANCE_FUSE";
+
+    uint16 public constant COMPOUND_V3_USDC_SUPPLY_FUSE_ID = 90;
+    string public constant COMPOUND_V3_USDC_SUPPLY_FUSE_NAME = "COMPOUND_V3_USDC_SUPPLY_FUSE";
+
+    uint16 public constant COMPOUND_V3_WETH_SUPPLY_FUSE_ID = 91;
+    string public constant COMPOUND_V3_WETH_SUPPLY_FUSE_NAME = "COMPOUND_V3_WETH_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_1_SUPPLY_FUSE_ID = 92;
+    string public constant ERC4626_MARKET_1_SUPPLY_FUSE_NAME = "ERC4626_MARKET_1_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_2_SUPPLY_FUSE_ID = 93;
+    string public constant ERC4626_MARKET_2_SUPPLY_FUSE_NAME = "ERC4626_MARKET_2_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_3_SUPPLY_FUSE_ID = 94;
+    string public constant ERC4626_MARKET_3_SUPPLY_FUSE_NAME = "ERC4626_MARKET_3_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_4_SUPPLY_FUSE_ID = 95;
+    string public constant ERC4626_MARKET_4_SUPPLY_FUSE_NAME = "ERC4626_MARKET_4_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_5_SUPPLY_FUSE_ID = 96;
+    string public constant ERC4626_MARKET_5_SUPPLY_FUSE_NAME = "ERC4626_MARKET_5_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_6_SUPPLY_FUSE_ID = 97;
+    string public constant ERC4626_MARKET_6_SUPPLY_FUSE_NAME = "ERC4626_MARKET_6_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_7_SUPPLY_FUSE_ID = 98;
+    string public constant ERC4626_MARKET_7_SUPPLY_FUSE_NAME = "ERC4626_MARKET_7_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_8_SUPPLY_FUSE_ID = 99;
+    string public constant ERC4626_MARKET_8_SUPPLY_FUSE_NAME = "ERC4626_MARKET_8_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_9_SUPPLY_FUSE_ID = 100;
+    string public constant ERC4626_MARKET_9_SUPPLY_FUSE_NAME = "ERC4626_MARKET_9_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_10_SUPPLY_FUSE_ID = 101;
+    string public constant ERC4626_MARKET_10_SUPPLY_FUSE_NAME = "ERC4626_MARKET_10_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_11_SUPPLY_FUSE_ID = 102;
+    string public constant ERC4626_MARKET_11_SUPPLY_FUSE_NAME = "ERC4626_MARKET_11_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_12_SUPPLY_FUSE_ID = 103;
+    string public constant ERC4626_MARKET_12_SUPPLY_FUSE_NAME = "ERC4626_MARKET_12_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_13_SUPPLY_FUSE_ID = 104;
+    string public constant ERC4626_MARKET_13_SUPPLY_FUSE_NAME = "ERC4626_MARKET_13_SUPPLY_FUSE";
+
+    uint16 public constant ERC4626_MARKET_14_SUPPLY_FUSE_ID = 105;
+    string public constant ERC4626_MARKET_14_SUPPLY_FUSE_NAME = "ERC4626_MARKET_14_SUPPLY_FUSE";
+
+    function getAllFuseIds() internal pure returns (uint16[] memory) {
+        uint16[] memory fuseIds = new uint16[](105);
+        fuseIds[0] = AAVE_V2_BALANCE_FUSE_ID;
+        fuseIds[1] = AAVE_V2_SUPPLY_FUSE_ID;
+        fuseIds[2] = AAVE_V3_BALANCE_FUSE_ID;
+        fuseIds[3] = AAVE_V3_SUPPLY_FUSE_ID;
+        fuseIds[4] = AAVE_V3_BORROW_FUSE_ID;
         fuseIds[5] = BURN_REQUEST_FEE_FUSE_ID;
         fuseIds[6] = SPARK_BALANCE_FUSE_ID;
         fuseIds[7] = SPARK_SUPPLY_FUSE_ID;
-        fuseIds[8] = COMPOUNDV2_BALANCE_FUSE_ID;
-        fuseIds[9] = COMPOUNDV2_SUPPLY_FUSE_ID;
-        fuseIds[10] = COMPOUNDV3_BALANCE_FUSE_ID;
-        fuseIds[11] = COMPOUNDV3_SUPPLY_FUSE_ID;
-        fuseIds[12] = COMPOUNDV3_CLAIM_FUSE_ID;
+        fuseIds[8] = COMPOUND_V2_BALANCE_FUSE_ID;
+        fuseIds[9] = COMPOUND_V2_SUPPLY_FUSE_ID;
+        fuseIds[10] = COMPOUND_V3_BALANCE_FUSE_ID;
+        fuseIds[11] = COMPOUND_V3_SUPPLY_FUSE_ID;
+        fuseIds[12] = COMPOUND_V3_CLAIM_FUSE_ID;
         fuseIds[13] = CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE_ID;
         fuseIds[14] = CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE_ID;
         fuseIds[15] = CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE_ID;
@@ -221,18 +342,18 @@ library FuseTypes {
         fuseIds[19] = ERC20_BALANCE_FUSE_ID;
         fuseIds[20] = ERC4626_BALANCE_FUSE_ID;
         fuseIds[21] = ERC4626_SUPPLY_FUSE_ID;
-        fuseIds[22] = EULERV2_BALANCE_FUSE_ID;
-        fuseIds[23] = EULERV2_SUPPLY_FUSE_ID;
-        fuseIds[24] = EULERV2_BORROW_FUSE_ID;
-        fuseIds[25] = EULERV2_COLLATERAL_FUSE_ID;
-        fuseIds[26] = EULERV2_CONTROLLER_FUSE_ID;
+        fuseIds[22] = EULER_V2_BALANCE_FUSE_ID;
+        fuseIds[23] = EULER_V2_SUPPLY_FUSE_ID;
+        fuseIds[24] = EULER_V2_BORROW_FUSE_ID;
+        fuseIds[25] = EULER_V2_COLLATERAL_FUSE_ID;
+        fuseIds[26] = EULER_V2_CONTROLLER_FUSE_ID;
         fuseIds[27] = FLUID_INSTADAPP_STAKING_BALANCE_FUSE_ID;
         fuseIds[28] = FLUID_INSTADAPP_STAKING_SUPPLY_FUSE_ID;
         fuseIds[29] = FLUID_INSTADAPP_CLAIM_FUSE_ID;
         fuseIds[30] = FLUID_PROOF_CLAIM_FUSE_ID;
-        fuseIds[31] = GEARBOXV3_FARM_BALANCE_FUSE_ID;
-        fuseIds[32] = GEARBOXV3_FARM_SUPPLY_FUSE_ID;
-        fuseIds[33] = GEARBOXV3_FARM_D_TOKEN_CLAIM_FUSE_ID;
+        fuseIds[31] = GEARBOX_V3_FARM_BALANCE_FUSE_ID;
+        fuseIds[32] = GEARBOX_V3_FARM_SUPPLY_FUSE_ID;
+        fuseIds[33] = GEARBOX_V3_FARM_D_TOKEN_CLAIM_FUSE_ID;
         fuseIds[34] = HARVEST_DO_HARD_WORK_FUSE_ID;
         fuseIds[35] = MOONWELL_BALANCE_FUSE_ID;
         fuseIds[36] = MOONWELL_SUPPLY_FUSE_ID;
@@ -264,24 +385,64 @@ library FuseTypes {
         fuseIds[62] = UNIVERSAL_TOKEN_SWAPPER_FUSE_ID;
         fuseIds[63] = UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE_ID;
         fuseIds[64] = UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE_ID;
+        fuseIds[65] = AAVE_V3_WITH_PRICE_ORACLE_BALANCE_FUSE_ID;
+        fuseIds[66] = FLUID_INSTADAPP_POOL_SUPPLY_FUSE_ID;
+        fuseIds[67] = FLUID_INSTADAPP_POOL_BALANCE_FUSE_ID;
+        fuseIds[68] = PENDLE_BALANCE_FUSE_ID;
+        fuseIds[69] = UNIVERSAL_READER_BALANCE_FUSE_ID;
+        fuseIds[70] = META_MORPHO_MARKET_0001_SUPPLY_FUSE_ID;
+        fuseIds[71] = META_MORPHO_MARKET_0001_BALANCE_FUSE_ID;
+        fuseIds[72] = UNISWAP_V3_SWAP_POSITIONS_BALANCE_FUSE_ID;
+        fuseIds[73] = COMPOUND_V3_USDC_BALANCE_FUSE_ID;
+        fuseIds[74] = COMPOUND_V3_WETH_BALANCE_FUSE_ID;
+        fuseIds[75] = ERC4626_MARKET_1_BALANCE_FUSE_ID;
+        fuseIds[76] = ERC4626_MARKET_2_BALANCE_FUSE_ID;
+        fuseIds[77] = ERC4626_MARKET_3_BALANCE_FUSE_ID;
+        fuseIds[78] = ERC4626_MARKET_4_BALANCE_FUSE_ID;
+        fuseIds[79] = ERC4626_MARKET_5_BALANCE_FUSE_ID;
+        fuseIds[80] = ERC4626_MARKET_6_BALANCE_FUSE_ID;
+        fuseIds[81] = ERC4626_MARKET_7_BALANCE_FUSE_ID;
+        fuseIds[82] = ERC4626_MARKET_8_BALANCE_FUSE_ID;
+        fuseIds[83] = ERC4626_MARKET_9_BALANCE_FUSE_ID;
+        fuseIds[84] = ERC4626_MARKET_10_BALANCE_FUSE_ID;
+        fuseIds[85] = ERC4626_MARKET_11_BALANCE_FUSE_ID;
+        fuseIds[86] = ERC4626_MARKET_12_BALANCE_FUSE_ID;
+        fuseIds[87] = ERC4626_MARKET_13_BALANCE_FUSE_ID;
+        fuseIds[88] = ERC4626_MARKET_14_BALANCE_FUSE_ID;
+        fuseIds[89] = COMPOUND_V3_USDC_SUPPLY_FUSE_ID;
+        fuseIds[90] = COMPOUND_V3_WETH_SUPPLY_FUSE_ID;
+        fuseIds[91] = ERC4626_MARKET_1_SUPPLY_FUSE_ID;
+        fuseIds[92] = ERC4626_MARKET_2_SUPPLY_FUSE_ID;
+        fuseIds[93] = ERC4626_MARKET_3_SUPPLY_FUSE_ID;
+        fuseIds[94] = ERC4626_MARKET_4_SUPPLY_FUSE_ID;
+        fuseIds[95] = ERC4626_MARKET_5_SUPPLY_FUSE_ID;
+        fuseIds[96] = ERC4626_MARKET_6_SUPPLY_FUSE_ID;
+        fuseIds[97] = ERC4626_MARKET_7_SUPPLY_FUSE_ID;
+        fuseIds[98] = ERC4626_MARKET_8_SUPPLY_FUSE_ID;
+        fuseIds[99] = ERC4626_MARKET_9_SUPPLY_FUSE_ID;
+        fuseIds[100] = ERC4626_MARKET_10_SUPPLY_FUSE_ID;
+        fuseIds[101] = ERC4626_MARKET_11_SUPPLY_FUSE_ID;
+        fuseIds[102] = ERC4626_MARKET_12_SUPPLY_FUSE_ID;
+        fuseIds[103] = ERC4626_MARKET_13_SUPPLY_FUSE_ID;
+        fuseIds[104] = ERC4626_MARKET_14_SUPPLY_FUSE_ID;
         return fuseIds;
     }
 
-    function getAllFuseName() internal pure returns (string[] memory) {
-        string[] memory fuseNames = new string[](65);
-        fuseNames[0] = AAVEV2_BALANCE_FUSE_NAME;
-        fuseNames[1] = AAVEV2_SUPPLY_FUSE_NAME;
-        fuseNames[2] = AAVEV3_BALANCE_FUSE_NAME;
-        fuseNames[3] = AAVEV3_SUPPLY_FUSE_NAME;
-        fuseNames[4] = AAVEV3_BORROW_FUSE_NAME;
+    function getAllFuseNames() internal pure returns (string[] memory) {
+        string[] memory fuseNames = new string[](105);
+        fuseNames[0] = AAVE_V2_BALANCE_FUSE_NAME;
+        fuseNames[1] = AAVE_V2_SUPPLY_FUSE_NAME;
+        fuseNames[2] = AAVE_V3_BALANCE_FUSE_NAME;
+        fuseNames[3] = AAVE_V3_SUPPLY_FUSE_NAME;
+        fuseNames[4] = AAVE_V3_BORROW_FUSE_NAME;
         fuseNames[5] = BURN_REQUEST_FEE_FUSE_NAME;
         fuseNames[6] = SPARK_BALANCE_FUSE_NAME;
         fuseNames[7] = SPARK_SUPPLY_FUSE_NAME;
-        fuseNames[8] = COMPOUNDV2_BALANCE_FUSE_NAME;
-        fuseNames[9] = COMPOUNDV2_SUPPLY_FUSE_NAME;
-        fuseNames[10] = COMPOUNDV3_BALANCE_FUSE_NAME;
-        fuseNames[11] = COMPOUNDV3_SUPPLY_FUSE_NAME;
-        fuseNames[12] = COMPOUNDV3_CLAIM_FUSE_NAME;
+        fuseNames[8] = COMPOUND_V2_BALANCE_FUSE_NAME;
+        fuseNames[9] = COMPOUND_V2_SUPPLY_FUSE_NAME;
+        fuseNames[10] = COMPOUND_V3_BALANCE_FUSE_NAME;
+        fuseNames[11] = COMPOUND_V3_SUPPLY_FUSE_NAME;
+        fuseNames[12] = COMPOUND_V3_CLAIM_FUSE_NAME;
         fuseNames[13] = CURVE_CHILD_LIQUIDITY_GAUGE_BALANCE_FUSE_NAME;
         fuseNames[14] = CURVE_CHILD_LIQUIDITY_GAUGE_SUPPLY_FUSE_NAME;
         fuseNames[15] = CURVE_CHILD_LIQUIDITY_GAUGE_ERC4626_BALANCE_FUSE_NAME;
@@ -291,18 +452,18 @@ library FuseTypes {
         fuseNames[19] = ERC20_BALANCE_FUSE_NAME;
         fuseNames[20] = ERC4626_BALANCE_FUSE_NAME;
         fuseNames[21] = ERC4626_SUPPLY_FUSE_NAME;
-        fuseNames[22] = EULERV2_BALANCE_FUSE_NAME;
-        fuseNames[23] = EULERV2_SUPPLY_FUSE_NAME;
-        fuseNames[24] = EULERV2_BORROW_FUSE_NAME;
-        fuseNames[25] = EULERV2_COLLATERAL_FUSE_NAME;
-        fuseNames[26] = EULERV2_CONTROLLER_FUSE_NAME;
+        fuseNames[22] = EULER_V2_BALANCE_FUSE_NAME;
+        fuseNames[23] = EULER_V2_SUPPLY_FUSE_NAME;
+        fuseNames[24] = EULER_V2_BORROW_FUSE_NAME;
+        fuseNames[25] = EULER_V2_COLLATERAL_FUSE_NAME;
+        fuseNames[26] = EULER_V2_CONTROLLER_FUSE_NAME;
         fuseNames[27] = FLUID_INSTADAPP_STAKING_BALANCE_FUSE_NAME;
         fuseNames[28] = FLUID_INSTADAPP_STAKING_SUPPLY_FUSE_NAME;
         fuseNames[29] = FLUID_INSTADAPP_CLAIM_FUSE_NAME;
         fuseNames[30] = FLUID_PROOF_CLAIM_FUSE_NAME;
-        fuseNames[31] = GEARBOXV3_FARM_BALANCE_FUSE_NAME;
-        fuseNames[32] = GEARBOXV3_FARM_SUPPLY_FUSE_NAME;
-        fuseNames[33] = GEARBOXV3_FARM_D_TOKEN_CLAIM_FUSE_NAME;
+        fuseNames[31] = GEARBOX_V3_FARM_BALANCE_FUSE_NAME;
+        fuseNames[32] = GEARBOX_V3_FARM_SUPPLY_FUSE_NAME;
+        fuseNames[33] = GEARBOX_V3_FARM_D_TOKEN_CLAIM_FUSE_NAME;
         fuseNames[34] = HARVEST_DO_HARD_WORK_FUSE_NAME;
         fuseNames[35] = MOONWELL_BALANCE_FUSE_NAME;
         fuseNames[36] = MOONWELL_SUPPLY_FUSE_NAME;
@@ -334,6 +495,46 @@ library FuseTypes {
         fuseNames[62] = UNIVERSAL_TOKEN_SWAPPER_FUSE_NAME;
         fuseNames[63] = UNIVERSAL_TOKEN_SWAPPER_ETH_FUSE_NAME;
         fuseNames[64] = UNIVERSAL_TOKEN_SWAPPER_WITH_VERIFICATION_FUSE_NAME;
+        fuseNames[65] = AAVE_V3_WITH_PRICE_ORACLE_BALANCE_FUSE_NAME;
+        fuseNames[66] = FLUID_INSTADAPP_POOL_SUPPLY_FUSE_NAME;
+        fuseNames[67] = FLUID_INSTADAPP_POOL_BALANCE_FUSE_NAME;
+        fuseNames[68] = PENDLE_BALANCE_FUSE_NAME;
+        fuseNames[69] = UNIVERSAL_READER_BALANCE_FUSE_NAME;
+        fuseNames[70] = META_MORPHO_MARKET_0001_SUPPLY_FUSE_NAME;
+        fuseNames[71] = META_MORPHO_MARKET_0001_BALANCE_FUSE_NAME;
+        fuseNames[72] = UNISWAP_V3_SWAP_POSITIONS_BALANCE_FUSE_NAME;
+        fuseNames[73] = COMPOUND_V3_USDC_BALANCE_FUSE_NAME;
+        fuseNames[74] = COMPOUND_V3_WETH_BALANCE_FUSE_NAME;
+        fuseNames[75] = ERC4626_MARKET_1_BALANCE_FUSE_NAME;
+        fuseNames[76] = ERC4626_MARKET_2_BALANCE_FUSE_NAME;
+        fuseNames[77] = ERC4626_MARKET_3_BALANCE_FUSE_NAME;
+        fuseNames[78] = ERC4626_MARKET_4_BALANCE_FUSE_NAME;
+        fuseNames[79] = ERC4626_MARKET_5_BALANCE_FUSE_NAME;
+        fuseNames[80] = ERC4626_MARKET_6_BALANCE_FUSE_NAME;
+        fuseNames[81] = ERC4626_MARKET_7_BALANCE_FUSE_NAME;
+        fuseNames[82] = ERC4626_MARKET_8_BALANCE_FUSE_NAME;
+        fuseNames[83] = ERC4626_MARKET_9_BALANCE_FUSE_NAME;
+        fuseNames[84] = ERC4626_MARKET_10_BALANCE_FUSE_NAME;
+        fuseNames[85] = ERC4626_MARKET_11_BALANCE_FUSE_NAME;
+        fuseNames[86] = ERC4626_MARKET_12_BALANCE_FUSE_NAME;
+        fuseNames[87] = ERC4626_MARKET_13_BALANCE_FUSE_NAME;
+        fuseNames[88] = ERC4626_MARKET_14_BALANCE_FUSE_NAME;
+        fuseNames[89] = COMPOUND_V3_USDC_SUPPLY_FUSE_NAME;
+        fuseNames[90] = COMPOUND_V3_WETH_SUPPLY_FUSE_NAME;
+        fuseNames[91] = ERC4626_MARKET_1_SUPPLY_FUSE_NAME;
+        fuseNames[92] = ERC4626_MARKET_2_SUPPLY_FUSE_NAME;
+        fuseNames[93] = ERC4626_MARKET_3_SUPPLY_FUSE_NAME;
+        fuseNames[94] = ERC4626_MARKET_4_SUPPLY_FUSE_NAME;
+        fuseNames[95] = ERC4626_MARKET_5_SUPPLY_FUSE_NAME;
+        fuseNames[96] = ERC4626_MARKET_6_SUPPLY_FUSE_NAME;
+        fuseNames[97] = ERC4626_MARKET_7_SUPPLY_FUSE_NAME;
+        fuseNames[98] = ERC4626_MARKET_8_SUPPLY_FUSE_NAME;
+        fuseNames[99] = ERC4626_MARKET_9_SUPPLY_FUSE_NAME;
+        fuseNames[100] = ERC4626_MARKET_10_SUPPLY_FUSE_NAME;
+        fuseNames[101] = ERC4626_MARKET_11_SUPPLY_FUSE_NAME;
+        fuseNames[102] = ERC4626_MARKET_12_SUPPLY_FUSE_NAME;
+        fuseNames[103] = ERC4626_MARKET_13_SUPPLY_FUSE_NAME;
+        fuseNames[104] = ERC4626_MARKET_14_SUPPLY_FUSE_NAME;
         return fuseNames;
     }
 }

--- a/contracts/libraries/StringConverter.sol
+++ b/contracts/libraries/StringConverter.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+library StringConverter {
+    // Optimized function - packs multiple characters into each bytes32
+    function toBytes32(string memory s) internal pure returns (bytes32[] memory) {
+        bytes memory b = bytes(s);
+        uint256 charsPerBytes32 = 32; // Each bytes32 can hold 32 characters
+        uint256 arrayLength = (b.length + charsPerBytes32 - 1) / charsPerBytes32; // Ceiling division
+        bytes32[] memory result = new bytes32[](arrayLength);
+
+        for (uint256 i; i < arrayLength; i++) {
+            bytes32 packed = 0;
+            uint256 startIndex = i * charsPerBytes32;
+            uint256 endIndex = startIndex + charsPerBytes32;
+            if (endIndex > b.length) {
+                endIndex = b.length;
+            }
+
+            for (uint256 j = startIndex; j < endIndex; j++) {
+                uint256 shift = (j - startIndex) * 8;
+                packed |= bytes32(uint256(uint8(b[j])) << shift);
+            }
+            result[i] = packed;
+        }
+        return result;
+    }
+
+    // Optimized function - extracts multiple characters from each bytes32
+    function fromBytes32(bytes32[] memory b) internal pure returns (string memory) {
+        uint256 totalLength = 0;
+
+        // Calculate total length (all bytes32 are full except possibly the last one)
+        if (b.length > 0) {
+            totalLength = (b.length - 1) * 32;
+            // For the last bytes32, we need to count non-zero bytes
+            bytes32 lastBytes32 = b[b.length - 1];
+            for (uint256 i = 0; i < 32; i++) {
+                uint8 byteValue = uint8(uint256(lastBytes32 >> (i * 8)));
+                if (byteValue != 0) {
+                    totalLength++;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        bytes memory result = new bytes(totalLength);
+        uint256 resultIndex = 0;
+
+        for (uint256 i = 0; i < b.length; i++) {
+            bytes32 currentBytes32 = b[i];
+            uint256 maxChars = (i == b.length - 1) ? 32 : 32; // Last one might be partially filled
+
+            for (uint256 j = 0; j < maxChars && resultIndex < totalLength; j++) {
+                uint8 byteValue = uint8(uint256(currentBytes32 >> (j * 8)));
+                if (byteValue != 0) {
+                    result[resultIndex] = bytes1(byteValue);
+                    resultIndex++;
+                } else {
+                    break; // Stop at first null byte
+                }
+            }
+        }
+
+        return string(result);
+    }
+}

--- a/test/fuses/whitelist/FuseWhitelistTest.t.sol
+++ b/test/fuses/whitelist/FuseWhitelistTest.t.sol
@@ -269,15 +269,15 @@ contract FuseWhitelistTest is Test {
         assertEq(fuseStatesNamesAfter.length, fuseStateNames.length, "Fuses names should be equal to the input");
 
         // Verify specific status values
-        assertEq(fuseStatesIdsAfter[0], 0, "Default status ID should be 0");
-        assertEq(fuseStatesIdsAfter[1], 1, "Active status ID should be 1");
-        assertEq(fuseStatesIdsAfter[2], 2, "Deprecated status ID should be 2");
-        assertEq(fuseStatesIdsAfter[3], 3, "Removed status ID should be 3");
+        assertEq(fuseStatesIdsAfter[0], 0, "DEFAULT status ID should be 0");
+        assertEq(fuseStatesIdsAfter[1], 1, "ACTIVE status ID should be 1");
+        assertEq(fuseStatesIdsAfter[2], 2, "DEPRECATED status ID should be 2");
+        assertEq(fuseStatesIdsAfter[3], 3, "REMOVED status ID should be 3");
 
-        assertEq(fuseStatesNamesAfter[0], "Default", "Default status name should be 'Default'");
-        assertEq(fuseStatesNamesAfter[1], "Active", "Active status name should be 'Active'");
-        assertEq(fuseStatesNamesAfter[2], "Deprecated", "Deprecated status name should be 'Deprecated'");
-        assertEq(fuseStatesNamesAfter[3], "Removed", "Removed status name should be 'Removed'");
+        assertEq(fuseStatesNamesAfter[0], "DEFAULT", "Default status name should be 'DEFAULT'");
+        assertEq(fuseStatesNamesAfter[1], "ACTIVE", "Active status name should be 'ACTIVE'");
+        assertEq(fuseStatesNamesAfter[2], "DEPRECATED", "Deprecated status name should be 'DEPRECATED'");
+        assertEq(fuseStatesNamesAfter[3], "REMOVED", "Removed status name should be 'REMOVED'");
     }
 
     function test_AddFuseStates_WithFuseStatusConstants_EventEmitted() public {
@@ -288,13 +288,13 @@ contract FuseWhitelistTest is Test {
         // Act & Assert
         vm.startPrank(FUSE_STATE_MANAGER_ROLE);
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.FuseStateAdded(0, "Default");
+        emit FuseWhitelistLib.FuseStateAdded(0, "DEFAULT");
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.FuseStateAdded(1, "Active");
+        emit FuseWhitelistLib.FuseStateAdded(1, "ACTIVE");
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.FuseStateAdded(2, "Deprecated");
+        emit FuseWhitelistLib.FuseStateAdded(2, "DEPRECATED");
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.FuseStateAdded(3, "Removed");
+        emit FuseWhitelistLib.FuseStateAdded(3, "REMOVED");
         bool result = _fuseWhitelist.addFuseStates(fuseStateIds, fuseStateNames);
         vm.stopPrank();
 
@@ -885,9 +885,9 @@ contract FuseWhitelistTest is Test {
         assertEq(statesIds[2], 2, "Third state ID should be 2");
 
         // Verify names
-        assertEq(statesNames[0], "Default", "First state name should be Default");
-        assertEq(statesNames[1], "Active", "Second state name should be Active");
-        assertEq(statesNames[2], "Inactive", "Third state name should be Inactive");
+        assertEq(statesNames[0], "DEFAULT", "First state name should be DEFAULT");
+        assertEq(statesNames[1], "ACTIVE", "Second state name should be ACTIVE");
+        assertEq(statesNames[2], "DEPRECATED", "Third state name should be DEPRECATED");
     }
 
     function test_GetFuseStates_Empty() public {
@@ -907,7 +907,7 @@ contract FuseWhitelistTest is Test {
         string memory description = _fuseWhitelist.getFuseStateName(1);
 
         // Assert
-        assertEq(description, "Active", "Fuse state description should match");
+        assertEq(description, "ACTIVE", "Fuse state description should match");
     }
 
     function test_GetFuseStateName_NonExistentState() public {
@@ -1306,8 +1306,8 @@ contract FuseWhitelistTest is Test {
 
     function test_AddAllFuseTypes_Success() public {
         // Arrange
-        uint16[] memory fuseTypeIds = FuseTypes.getAllFuseId();
-        string[] memory fuseTypeNames = FuseTypes.getAllFuseName();
+        uint16[] memory fuseTypeIds = FuseTypes.getAllFuseIds();
+        string[] memory fuseTypeNames = FuseTypes.getAllFuseNames();
 
         (uint16[] memory fuseTypesIdsBefore, string[] memory fuseTypesNamesBefore) = _fuseWhitelist.getFuseTypes();
 
@@ -1334,8 +1334,8 @@ contract FuseWhitelistTest is Test {
 
     function test_AddAllFuseTypes_EventEmitted() public {
         // Arrange
-        uint16[] memory fuseTypeIds = FuseTypes.getAllFuseId();
-        string[] memory fuseTypeNames = FuseTypes.getAllFuseName();
+        uint16[] memory fuseTypeIds = FuseTypes.getAllFuseIds();
+        string[] memory fuseTypeNames = FuseTypes.getAllFuseNames();
 
         // Act & Assert
         vm.startPrank(FUSE_TYPE_MANAGER_ROLE);
@@ -1375,10 +1375,10 @@ contract FuseWhitelistTest is Test {
         assertEq(metadataIdsAfter[2], 2, "Category Info ID should be 2");
         assertEq(metadataIdsAfter[3], 3, "Abi Version ID should be 3");
 
-        assertEq(metadataTypesAfter[0], "Audit_Status", "Audit Status name should be 'Audit_Status'");
-        assertEq(metadataTypesAfter[1], "Substrate_Info", "Substrate Info name should be 'Substrate_Info'");
-        assertEq(metadataTypesAfter[2], "Category_Info", "Category Info name should be 'Category_Info'");
-        assertEq(metadataTypesAfter[3], "Abi_Version", "Abi Version name should be 'Abi_Version'");
+        assertEq(metadataTypesAfter[0], "AUDIT_STATUS", "Audit Status name should be 'AUDIT_STATUS'");
+        assertEq(metadataTypesAfter[1], "SUBSTRATE_INFO", "Substrate Info name should be 'SUBSTRATE_INFO'");
+        assertEq(metadataTypesAfter[2], "CATEGORY_INFO", "Category Info name should be 'CATEGORY_INFO'");
+        assertEq(metadataTypesAfter[3], "ABI_VERSION", "Abi Version name should be 'ABI_VERSION'");
     }
 
     function test_AddMetadataTypes_WithFuseMetadataTypesConstants_EventEmitted() public {
@@ -1389,13 +1389,13 @@ contract FuseWhitelistTest is Test {
         // Act & Assert
         vm.startPrank(FUSE_METADATA_MANAGER_ROLE);
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.MetadataTypeAdded(0, "Audit_Status");
+        emit FuseWhitelistLib.MetadataTypeAdded(0, "AUDIT_STATUS");
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.MetadataTypeAdded(1, "Substrate_Info");
+        emit FuseWhitelistLib.MetadataTypeAdded(1, "SUBSTRATE_INFO");
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.MetadataTypeAdded(2, "Category_Info");
+        emit FuseWhitelistLib.MetadataTypeAdded(2, "CATEGORY_INFO");
         vm.expectEmit(true, true, true, true);
-        emit FuseWhitelistLib.MetadataTypeAdded(3, "Abi_Version");
+        emit FuseWhitelistLib.MetadataTypeAdded(3, "ABI_VERSION");
         bool result = _fuseWhitelist.addMetadataTypes(metadataIds, metadataTypes);
         vm.stopPrank();
 
@@ -1437,9 +1437,9 @@ contract FuseWhitelistTest is Test {
         fuseStateIds[1] = 1;
         fuseStateIds[2] = 2;
 
-        fuseStateNames[0] = "Default";
-        fuseStateNames[1] = "Active";
-        fuseStateNames[2] = "Inactive";
+        fuseStateNames[0] = "DEFAULT";
+        fuseStateNames[1] = "ACTIVE";
+        fuseStateNames[2] = "DEPRECATED";
 
         // Act
         vm.startPrank(FUSE_TYPE_MANAGER_ROLE);

--- a/test/libraries/StringConverter.t.sol
+++ b/test/libraries/StringConverter.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {StringConverter} from "../../contracts/libraries/StringConverter.sol";
+
+contract StringConverterTest is Test {
+    using StringConverter for string;
+
+    function test_toBytes32_emptyString() public {
+        string memory empty = "";
+        bytes32[] memory result = StringConverter.toBytes32(empty);
+
+        assertEq(result.length, 0, "Empty string should return empty array");
+    }
+
+    function test_toBytes32_singleCharacter() public {
+        string memory single = "a";
+        bytes32[] memory result = StringConverter.toBytes32(single);
+
+        assertEq(result.length, 1, "Single character should return array of length 1");
+        assertEq(result[0], bytes32(uint256(uint8(bytes1("a")))), "First character should be 'a'");
+    }
+
+    function test_toBytes32_exactly32Characters() public {
+        string memory exactly32 = "abcdefghijklmnopqrstuvwxyz123456";
+        bytes32[] memory result = StringConverter.toBytes32(exactly32);
+
+        assertEq(result.length, 1, "Exactly 32 characters should return array of length 1");
+
+        // Verify the packed bytes32 contains all characters
+        bytes32 expected = 0;
+        for (uint256 i = 0; i < 32; i++) {
+            expected |= bytes32(uint256(uint8(bytes1(bytes(exactly32)[i]))) << (i * 8));
+        }
+        assertEq(result[0], expected, "Packed bytes32 should match expected value");
+    }
+
+    function test_toBytes32_33Characters() public {
+        string memory thirtyThree = "abcdefghijklmnopqrstuvwxyz1234567";
+        bytes32[] memory result = StringConverter.toBytes32(thirtyThree);
+
+        assertEq(result.length, 2, "33 characters should return array of length 2");
+
+        // Verify first bytes32 contains first 32 characters
+        bytes32 expectedFirst = 0;
+        for (uint256 i = 0; i < 32; i++) {
+            expectedFirst |= bytes32(uint256(uint8(bytes(thirtyThree)[i])) << (i * 8));
+        }
+        assertEq(result[0], expectedFirst, "First bytes32 should contain first 32 characters");
+
+        // Verify second bytes32 contains the last character
+        assertEq(result[1], bytes32(uint256(uint8(bytes1("7")))), "Second bytes32 should contain '7'");
+    }
+
+    function test_toBytes32_64Characters() public {
+        string memory sixtyFour = "abcdefghijklmnopqrstuvwxyz1234567890123456789012345678901234";
+        bytes32[] memory result = StringConverter.toBytes32(sixtyFour);
+
+        // Calculate expected array length using ceiling division
+        uint256 expectedLength = (bytes(sixtyFour).length + 32 - 1) / 32;
+        assertEq(result.length, expectedLength, "64 characters should return correct array length");
+
+        // Verify round-trip conversion works
+        string memory roundTrip = StringConverter.fromBytes32(result);
+        assertEq(roundTrip, sixtyFour, "Round-trip conversion should preserve string");
+    }
+
+    function test_toBytes32_65Characters() public {
+        string memory sixtyFive = "abcdefghijklmnopqrstuvwxyz12345678901234567890123456789012345";
+        bytes32[] memory result = StringConverter.toBytes32(sixtyFive);
+
+        // Calculate expected array length using ceiling division
+        uint256 expectedLength = (bytes(sixtyFive).length + 32 - 1) / 32;
+        assertEq(result.length, expectedLength, "65 characters should return correct array length");
+
+        // Verify round-trip conversion works
+        string memory roundTrip = StringConverter.fromBytes32(result);
+        assertEq(roundTrip, sixtyFive, "Round-trip conversion should preserve string");
+    }
+
+    function test_toBytes32_specialCharacters() public {
+        string memory special = "!@#$%^&*()_+-=[]{}|;':\",./<>?";
+        bytes32[] memory result = StringConverter.toBytes32(special);
+
+        assertEq(result.length, 1, "Special characters should fit in one bytes32");
+
+        // Verify the packed bytes32 contains all special characters
+        bytes32 expected = 0;
+        for (uint256 i = 0; i < bytes(special).length; i++) {
+            expected |= bytes32(uint256(uint8(bytes(special)[i])) << (i * 8));
+        }
+        assertEq(result[0], expected, "Packed bytes32 should match expected value");
+    }
+
+    function test_fromBytes32_emptyArray() public {
+        bytes32[] memory empty = new bytes32[](0);
+        string memory result = StringConverter.fromBytes32(empty);
+
+        assertEq(result, "", "Empty array should return empty string");
+    }
+
+    function test_fromBytes32_singleCharacter() public {
+        bytes32[] memory single = new bytes32[](1);
+        single[0] = bytes32(uint256(uint8(bytes1("a"))));
+
+        string memory result = StringConverter.fromBytes32(single);
+
+        assertEq(result, "a", "Single character should be correctly extracted");
+    }
+
+    function test_fromBytes32_exactly32Characters() public {
+        string memory original = "abcdefghijklmnopqrstuvwxyz123456";
+        bytes32[] memory packed = StringConverter.toBytes32(original);
+        string memory result = StringConverter.fromBytes32(packed);
+
+        assertEq(result, original, "Round-trip conversion should preserve string");
+    }
+
+    function test_fromBytes32_33Characters() public {
+        string memory original = "abcdefghijklmnopqrstuvwxyz1234567";
+        bytes32[] memory packed = StringConverter.toBytes32(original);
+        string memory result = StringConverter.fromBytes32(packed);
+
+        assertEq(result, original, "Round-trip conversion should preserve string");
+    }
+
+    function test_fromBytes32_64Characters() public {
+        string memory original = "abcdefghijklmnopqrstuvwxyz1234567890123456789012345678901234";
+        bytes32[] memory packed = StringConverter.toBytes32(original);
+        string memory result = StringConverter.fromBytes32(packed);
+
+        assertEq(result, original, "Round-trip conversion should preserve string");
+    }
+
+    function test_fromBytes32_65Characters() public {
+        string memory original = "abcdefghijklmnopqrstuvwxyz12345678901234567890123456789012345";
+        bytes32[] memory packed = StringConverter.toBytes32(original);
+        string memory result = StringConverter.fromBytes32(packed);
+
+        assertEq(result, original, "Round-trip conversion should preserve string");
+    }
+
+    function test_fromBytes32_specialCharacters() public {
+        string memory original = "!@#$%^&*()_+-=[]{}|;':\",./<>?";
+        bytes32[] memory packed = StringConverter.toBytes32(original);
+        string memory result = StringConverter.fromBytes32(packed);
+
+        assertEq(result, original, "Round-trip conversion should preserve special characters");
+    }
+
+    function test_fromBytes32_withNullBytes() public {
+        bytes32[] memory withNulls = new bytes32[](1);
+        // Set first 3 bytes to 'abc', rest to null
+        withNulls[0] = bytes32(
+            uint256(uint8(bytes1("a"))) | (uint256(uint8(bytes1("b"))) << 8) | (uint256(uint8(bytes1("c"))) << 16)
+        );
+
+        string memory result = StringConverter.fromBytes32(withNulls);
+
+        assertEq(result, "abc", "Should stop at first null byte");
+    }
+
+    function test_fromBytes32_partialLastBytes32() public {
+        bytes32[] memory partialArray = new bytes32[](2);
+        // First bytes32: full 32 characters
+        partialArray[0] = bytes32(
+            uint256(uint8(bytes1("a"))) |
+                (uint256(uint8(bytes1("b"))) << 8) |
+                (uint256(uint8(bytes1("c"))) << 16) |
+                // ... fill with more characters
+                (uint256(uint8(bytes1("z"))) << 248)
+        );
+        // Second bytes32: only 3 characters
+        partialArray[1] = bytes32(
+            uint256(uint8(bytes1("x"))) | (uint256(uint8(bytes1("y"))) << 8) | (uint256(uint8(bytes1("z"))) << 16)
+        );
+
+        string memory result = StringConverter.fromBytes32(partialArray);
+
+        // Should extract all characters up to the null byte in the second bytes32
+        assertEq(bytes(result).length, 35, "Should extract 32 + 3 = 35 characters");
+    }
+
+    function test_roundTrip_variousLengths() public {
+        string[] memory testStrings = new string[](5);
+        testStrings[0] = "";
+        testStrings[1] = "a";
+        testStrings[2] = "hello world";
+        testStrings[3] = "abcdefghijklmnopqrstuvwxyz123456";
+        testStrings[
+            4
+        ] = "This is a very long string that should be split across multiple bytes32 arrays to test the conversion logic thoroughly";
+
+        for (uint256 i = 0; i < testStrings.length; i++) {
+            bytes32[] memory packed = StringConverter.toBytes32(testStrings[i]);
+            string memory result = StringConverter.fromBytes32(packed);
+
+            assertEq(result, testStrings[i], string.concat("Round-trip failed for test string ", vm.toString(i)));
+        }
+    }
+}


### PR DESCRIPTION
* IL-6175 Add Fuse whitelist metadata content

* IL-6175 Fix variable type to string in whitelist metadata

* IL-6175 Add missing fuse categories to metadata whitelist

* IL-6175 Add ID suffix to metadata constants name

* IL-6175 Change all whitelist contants to public

* IL-6175 Change metadata values to codes

* IL-6175 Fix method names in FuseTypes.sol

* IL-6175 Change visibility of list methods

* IL-6175 Add stringToBytes32Array method

* String Converter

* IL-6175 Change codes to upper case

* IL-6175 Add missing types to FuseTypes.sol

* IL-6175 Fix size

* IL-6175 Add missing types to FuseTypes.sol

* IL-6175 Add missing types to FuseMetadataTypes.sol

* IL-6175 Fix array size in FuseTypes.sol

* IL-6175 Change in addFuseToMarketId method to add to marketID only if fuse has MARKET_ID() method

* IL-6175 Fix method names in tests

* IL-6175 Change status names to upper cases in tests

* IL-6175 Change audit status codes to upper cases in tests

* IL-6175 Change audit status codes to upper cases in tests

---------