### PR TITLE
ci: bump foundry-toolchain to v1.9.1

### DIFF
--- a/.github/workflows/smart-contracts-build.yml
+++ b/.github/workflows/smart-contracts-build.yml
@@ -107,8 +107,8 @@ jobs:
                   key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
             - name: Setup Foundry
-              # from tag: v1.7.0
-              uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10
+              # from tag: v1.9.1
+              uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09
               with:
                   version: stable
 


### PR DESCRIPTION
Fixes CI failing on Setup Foundry: `foundryup: cannot execute binary file`.

Upstream rewrote foundryup as a binary; v1.7.0 of the action runs it via bash. Ref: foundry-rs/foundry-toolchain#170.

Reusable workflow is taken from main (pull_request_target), so this must merge before #548 can pass.