### PR TITLE
ci: disable forge isolate mode for transient storage tests

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -18,6 +18,9 @@ remappings = [
 optimizer_runs = 10000000
 ignored_error_codes = [5667, 9302, 2462, 5574, 8760]
 evm_version = "cancun"
+# Forge 1.8+ defaults to --isolate (each top-level call is a separate tx), which clears
+# transient storage between calls. Fuse tests set transient inputs and read them in separate calls.
+isolate = false
 ffi = true
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config
 


### PR DESCRIPTION
Forge 1.8.0 made `--isolate` the default, which clears transient storage between top-level calls. 181 tests across 17 suites fail (see #550 CI). Restores 1.7.x behaviour via `isolate = false`.