### PR TITLE
sync: changes from private repo (2026-09-09)

### DIFF
--- a/contracts/interfaces/IIporFusionAccessManager.sol
+++ b/contracts/interfaces/IIporFusionAccessManager.sol
@@ -5,10 +5,21 @@ import {IAccessManager} from "@openzeppelin/contracts/access/manager/IAccessMana
 
 /// @title Interface for the IporFusionAccessManager contract that manages access control for the IporFusion contract and its contract satellites
 interface IIporFusionAccessManager is IAccessManager {
-    /// @notice The minimal delay required for the timelocked functions, value is set in the constructor, cannot be changed
-    /// @return The minimal delay in seconds
+    /// @notice The redemption delay currently in force - the cooling period between a deposit and the moment
+    /// the depositing account may withdraw, redeem or transfer its shares. Set at creation and changeable
+    /// afterwards by the OWNER_ROLE via PlasmaVaultGovernance.setRedemptionDelay.
+    /// @return The current redemption delay in seconds
     // solhint-disable-next-line func-name-mixedcase
     function REDEMPTION_DELAY_IN_SECONDS() external view returns (uint256);
+
+    /// @notice Sets the vault-wide redemption delay. The new value governs every account immediately -
+    /// lowering the delay releases accounts that already deposited, raising it extends their locks,
+    /// measured from their own deposits.
+    /// @dev Restricted to the TECH_PLASMA_VAULT_ROLE. Governance uses PlasmaVaultGovernance.setRedemptionDelay,
+    /// which forwards here and is subject to the OWNER_ROLE execution delay (timelock).
+    /// @param redemptionDelayInSeconds_ The new redemption delay in seconds, reverts with
+    /// TooLongRedemptionDelay above MAX_REDEMPTION_DELAY_IN_SECONDS
+    function setRedemptionDelay(uint256 redemptionDelayInSeconds_) external;
 
     /// @notice Check if the caller can call the target with the given selector. Update the account lock time.
     /// @dev canCall cannot be a view function because it updates the account lock time.
@@ -41,9 +52,11 @@ interface IIporFusionAccessManager is IAccessManager {
     /// @return The minimal execution delay in seconds
     function getMinimalExecutionDelayForRole(uint64 roleId_) external view returns (uint256);
 
-    /// @notice Returns the account lock time for the specified account.
+    /// @notice Returns the effective unlock timestamp for the specified account under the current
+    /// redemption delay (last deposit timestamp + REDEMPTION_DELAY_IN_SECONDS). The value moves
+    /// immediately, in both directions, whenever the redemption delay is changed.
     /// @param account_ The account for which the account lock time is returned
-    /// @return The account lock time in seconds
+    /// @return The unlock timestamp, possibly in the past when the lock has expired, 0 when the account never deposited
     function getAccountLockTime(address account_) external view returns (uint256);
 
     /// @notice Returns the function selector for the scheduled operation that is currently being consumed.

--- a/contracts/interfaces/IPlasmaVaultGovernance.sol
+++ b/contracts/interfaces/IPlasmaVaultGovernance.sol
@@ -168,4 +168,13 @@ interface IPlasmaVaultGovernance {
     /// @param rolesIds_ The roles for which the minimal execution delay is set
     /// @param delays_ The minimal execution delays for the specified roles
     function setMinimalExecutionDelaysForRoles(uint64[] calldata rolesIds_, uint256[] calldata delays_) external;
+
+    /// @notice Sets the vault-wide redemption delay - the cooling period between a deposit and the moment
+    /// the depositing account may withdraw, redeem or transfer its shares. The new value governs every
+    /// account immediately, measured from each account's own last deposit.
+    /// @dev Forwards to IporFusionAccessManager.setRedemptionDelay. The owner-facing entry point lives on the
+    /// vault so the call is subject to the OWNER_ROLE execution delay (timelock) like every other governance function.
+    /// @param redemptionDelayInSeconds_ The new redemption delay in seconds, at most
+    /// IporFusionAccessManager.MAX_REDEMPTION_DELAY_IN_SECONDS
+    function setRedemptionDelay(uint256 redemptionDelayInSeconds_) external;
 }

--- a/contracts/managers/access/IporFusionAccessManager.sol
+++ b/contracts/managers/access/IporFusionAccessManager.sol
@@ -7,9 +7,13 @@ import {IIporFusionAccessManager} from "../../interfaces/IIporFusionAccessManage
 import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import {RedemptionDelayLib} from "./RedemptionDelayLib.sol";
+import {IporFusionAccessManagersStorageLib} from "./IporFusionAccessManagersStorageLib.sol";
 import {PlasmaVault} from "../../vaults/PlasmaVault.sol";
 import {RoleExecutionTimelockLib} from "./RoleExecutionTimelockLib.sol";
-import {IporFusionAccessManagerInitializationLib, InitializationData} from "./IporFusionAccessManagerInitializationLib.sol";
+import {
+    IporFusionAccessManagerInitializationLib,
+    InitializationData
+} from "./IporFusionAccessManagerInitializationLib.sol";
 import {Roles} from "../../libraries/Roles.sol";
 
 /**
@@ -31,6 +35,8 @@ import {Roles} from "../../libraries/Roles.sol";
  * - convertToPublicVault: Restricted to TECH_PLASMA_VAULT_ROLE
  * - enableTransferShares: Restricted to TECH_PLASMA_VAULT_ROLE
  * - setMinimalExecutionDelaysForRoles: Restricted to TECH_PLASMA_VAULT_ROLE
+ * - setRedemptionDelay: Restricted to TECH_PLASMA_VAULT_ROLE (the OWNER_ROLE reaches it through
+ *   PlasmaVaultGovernance.setRedemptionDelay, which is subject to the role's execution delay)
  * - grantRole: Restricted to authorized roles (via onlyAuthorized)
  *
  * Security features:
@@ -45,12 +51,12 @@ contract IporFusionAccessManager is Initializable, IIporFusionAccessManager, Acc
     error TooShortExecutionDelayForRole(uint64 roleId, uint32 executionDelay);
     error TooLongRedemptionDelay(uint256 redemptionDelayInSeconds);
 
+    /// @notice Emitted when the vault-wide redemption delay is changed
+    /// @param newRedemptionDelayInSeconds The redemption delay in force after the change
+    event RedemptionDelayUpdated(uint256 newRedemptionDelayInSeconds);
+
     /// @notice Maximum allowed redemption delay in seconds (7 days)
     uint256 public constant MAX_REDEMPTION_DELAY_IN_SECONDS = 7 days;
-
-    /// @notice Actual redemption delay in seconds for this instance
-    // solhint-disable-next-line var-name-mixedcase
-    uint256 public override REDEMPTION_DELAY_IN_SECONDS;
 
     /// @dev Flag to track custom schedule consumption
     bool private _customConsumingSchedule;
@@ -88,10 +94,7 @@ contract IporFusionAccessManager is Initializable, IIporFusionAccessManager, Acc
     /// @param redemptionDelayInSeconds_ The redemption delay in seconds
     /// @dev This method is used by both constructor and proxyInitialize to avoid code duplication
     function _initialize(address initialAdmin_, uint256 redemptionDelayInSeconds_) private {
-        if (redemptionDelayInSeconds_ > MAX_REDEMPTION_DELAY_IN_SECONDS) {
-            revert TooLongRedemptionDelay(redemptionDelayInSeconds_);
-        }
-        REDEMPTION_DELAY_IN_SECONDS = redemptionDelayInSeconds_;
+        _setRedemptionDelay(redemptionDelayInSeconds_);
         _grantRole(ADMIN_ROLE, initialAdmin_, 0, 0);
     }
 
@@ -211,6 +214,21 @@ contract IporFusionAccessManager is Initializable, IIporFusionAccessManager, Acc
     }
 
     /**
+     * @notice Sets the vault-wide redemption delay
+     * @param redemptionDelayInSeconds_ The new redemption delay in seconds
+     * @dev The new value governs every account immediately - each account's unlock time is computed
+     * at check time as its last deposit timestamp plus the current delay, so lowering the delay
+     * releases existing depositors and raising it extends their locks, measured from their own deposits.
+     * Governance calls it through PlasmaVaultGovernance.setRedemptionDelay - AccessManager cannot schedule
+     * its own custom functions, so a setter restricted here to the OWNER_ROLE could never be timelocked
+     * @custom:access Restricted to TECH_PLASMA_VAULT_ROLE (the PlasmaVault)
+     * @custom:error TooLongRedemptionDelay if redemptionDelayInSeconds_ exceeds MAX_REDEMPTION_DELAY_IN_SECONDS
+     */
+    function setRedemptionDelay(uint256 redemptionDelayInSeconds_) external override restricted {
+        _setRedemptionDelay(redemptionDelayInSeconds_);
+    }
+
+    /**
      * @notice Grants a role to an account with a specified execution delay
      * @param roleId_ The role identifier to grant
      * @param account_ The account to receive the role
@@ -246,10 +264,13 @@ contract IporFusionAccessManager is Initializable, IIporFusionAccessManager, Acc
     }
 
     /**
-     * @notice Retrieves the lock time for a specific account
+     * @notice Retrieves the effective unlock time for a specific account under the current redemption delay
      * @param account_ The account address to query
-     * @return The timestamp until which the account is locked for redemption operations
-     * @dev Used to enforce redemption delay periods after certain operations
+     * @return The timestamp until which the account is locked for redemption operations, computed as
+     * the account's last deposit timestamp plus the current REDEMPTION_DELAY_IN_SECONDS. May be in the
+     * past when the lock has already expired. Returns 0 when the account never deposited.
+     * @dev Used to enforce redemption delay periods after certain operations. The returned value moves
+     * immediately, in both directions, whenever the redemption delay is changed via setRedemptionDelay.
      * @custom:access No access restrictions - can be called by anyone
      * @custom:security
      * - Part of the redemption delay mechanism
@@ -258,6 +279,18 @@ contract IporFusionAccessManager is Initializable, IIporFusionAccessManager, Acc
      */
     function getAccountLockTime(address account_) external view override returns (uint256) {
         return RedemptionDelayLib.getAccountLockTime(account_);
+    }
+
+    /**
+     * @notice Retrieves the current vault-wide redemption delay
+     * @return The redemption delay in seconds, changeable by the OWNER_ROLE via PlasmaVaultGovernance.setRedemptionDelay
+     * @dev The value lives in ERC-7201 namespaced storage; the constant-style name is kept for
+     * ABI compatibility with instances deployed when the value was set once at initialization
+     * @custom:access No access restrictions - can be called by anyone
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function REDEMPTION_DELAY_IN_SECONDS() external view override returns (uint256) {
+        return IporFusionAccessManagersStorageLib.getRedemptionDelay();
     }
 
     /**
@@ -272,6 +305,14 @@ contract IporFusionAccessManager is Initializable, IIporFusionAccessManager, Acc
      */
     function isConsumingScheduledOp() external view override returns (bytes4) {
         return _customConsumingSchedule ? this.isConsumingScheduledOp.selector : bytes4(0);
+    }
+
+    function _setRedemptionDelay(uint256 redemptionDelayInSeconds_) private {
+        if (redemptionDelayInSeconds_ > MAX_REDEMPTION_DELAY_IN_SECONDS) {
+            revert TooLongRedemptionDelay(redemptionDelayInSeconds_);
+        }
+        IporFusionAccessManagersStorageLib.setRedemptionDelay(redemptionDelayInSeconds_);
+        emit RedemptionDelayUpdated(redemptionDelayInSeconds_);
     }
 
     function _grantRoleInternal(uint64 roleId_, address account_, uint32 executionDelay_) internal {

--- a/contracts/managers/access/IporFusionAccessManagersStorageLib.sol
+++ b/contracts/managers/access/IporFusionAccessManagersStorageLib.sol
@@ -1,18 +1,30 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity 0.8.30;
 
-import {IIporFusionAccessManager} from "../../interfaces/IIporFusionAccessManager.sol";
+/**
+ * @title Redemption Lock Start Times Storage Structure
+ * @notice Stores the moment each account last deposited or minted (the start of its redemption lock)
+ * @dev The effective unlock timestamp is computed at read time as
+ * lockStartTime + the current redemption delay, so the currently configured delay always governs
+ * @custom:storage-location erc7201:io.ipor.managers.access.RedemptionLockStartTimes
+ */
+struct RedemptionLockStartTimes {
+    /// @notice Maps user addresses to the timestamp of their last deposit or mint
+    /// @dev Recorded unconditionally, even when the redemption delay is 0, so a later
+    /// increase of the delay reaches accounts that deposited while it was 0
+    mapping(address account => uint256 lockStartTime) lockStartTime;
+}
 
 /**
- * @title Redemption Locks Storage Structure
- * @notice Manages time-based locks for redemption operations per account
- * @dev Uses ERC-7201 namespaced storage pattern to prevent storage collisions
- * @custom:storage-location erc7201:io.ipor.managers.access.RedemptionLocks
+ * @title Redemption Delay Storage Structure
+ * @notice Stores the vault-wide redemption delay applied to every account's lock start time
+ * @dev Changeable after vault creation via PlasmaVaultGovernance.setRedemptionDelay, which forwards to
+ * IporFusionAccessManager.setRedemptionDelay (TECH_PLASMA_VAULT_ROLE)
+ * @custom:storage-location erc7201:io.ipor.managers.access.RedemptionDelay
  */
-struct RedemptionLocks {
-    /// @notice Maps user addresses to their unlock timestamp (block.timestamp + redemptionDelay)
-    /// @dev Used to enforce redemption delays after deposits. The stored value is the earliest time a redemption is allowed.
-    mapping(address account => uint256 unlockTime) redemptionLock;
+struct RedemptionDelay {
+    /// @notice The current redemption delay in seconds
+    uint256 redemptionDelayInSeconds;
 }
 
 /**
@@ -45,10 +57,17 @@ struct InitializationFlag {
  * @custom:security-contact security@ipor.io
  */
 library IporFusionAccessManagersStorageLib {
+    /// @notice Storage slot for RedemptionLockStartTimes
+    /// @dev Replaces the retired namespace io.ipor.managers.access.RedemptionLocks (slot
+    /// 0x5e07febb5bd598f6b55406c9bf939d497fd39a2dbc2b5891f20f6640c3f32500, held absolute unlock
+    /// timestamps fixed at deposit time); do not re-derive that namespace
+    /// @dev Computed as: keccak256(abi.encode(uint256(keccak256("io.ipor.managers.access.RedemptionLockStartTimes")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant REDEMPTION_LOCK_START_TIMES =
+        0x83e7bafd2a5059a7a3f8f00883c599ce24355cc422725b4bf7e796d03c954a00;
 
-    /// @notice Storage slot for RedemptionLocks
-    /// @dev Computed as: keccak256(abi.encode(uint256(keccak256("io.ipor.managers.access.RedemptionLocks")) - 1)) & ~bytes32(uint256(0xff))
-    bytes32 private constant REDEMPTION_LOCKS = 0x5e07febb5bd598f6b55406c9bf939d497fd39a2dbc2b5891f20f6640c3f32500;
+    /// @notice Storage slot for RedemptionDelay
+    /// @dev Computed as: keccak256(abi.encode(uint256(keccak256("io.ipor.managers.access.RedemptionDelay")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant REDEMPTION_DELAY = 0x145eef5574c3cce4d2653445e6a5a4d0b02eafca2d8fced992bac1eca819d500;
 
     /// @notice Storage slot for MinimalExecutionDelayForRole
     /// @dev Computed as: keccak256(abi.encode(uint256(keccak256("io.ipor.managers.access.MinimalExecutionDelayForRole")) - 1)) & ~bytes32(uint256(0xff))
@@ -58,11 +77,6 @@ library IporFusionAccessManagersStorageLib {
     /// @notice Storage slot for InitializationFlag
     /// @dev Computed as: keccak256(abi.encode(uint256(keccak256("io.ipor.managers.access.InitializationFlag")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant INITIALIZATION_FLAG = 0x25e922da7c41a5d012dbc2479dd6a7bd57760f359ea3a3be13608d287fc89400;
-
-    /// @notice Emitted when an account's redemption delay is updated
-    /// @param account The address of the affected account
-    /// @param redemptionDelay The new redemption delay timestamp
-    event RedemptionDelayForAccountUpdated(address account, uint256 redemptionDelay);
 
     /**
      * @notice Retrieves the initialization flag storage pointer
@@ -91,30 +105,66 @@ library IporFusionAccessManagersStorageLib {
     }
 
     /**
-     * @notice Retrieves the redemption locks storage pointer
+     * @notice Retrieves the redemption lock start times storage pointer
      * @dev Uses assembly to access the predetermined storage slot
-     * @return redemptionLocks Storage pointer to the redemption locks mapping
+     * @return redemptionLockStartTimes Storage pointer to the redemption lock start times mapping
      */
-    function getRedemptionLocks() internal pure returns (RedemptionLocks storage redemptionLocks) {
+    function getRedemptionLockStartTimes()
+        internal
+        pure
+        returns (RedemptionLockStartTimes storage redemptionLockStartTimes)
+    {
         assembly {
-            redemptionLocks.slot := REDEMPTION_LOCKS
+            redemptionLockStartTimes.slot := REDEMPTION_LOCK_START_TIMES
         }
     }
 
     /**
-     * @notice Sets redemption lock for an account after deposit or mint operations
-     * @dev Enforces a time-based lock to prevent immediate withdrawals after deposits
-     * @param account_ The address to set the redemption lock for
+     * @notice Retrieves the current vault-wide redemption delay
+     * @return The redemption delay in seconds
+     */
+    function getRedemptionDelay() internal view returns (uint256) {
+        return _getRedemptionDelay().redemptionDelayInSeconds;
+    }
+
+    /**
+     * @notice Sets the vault-wide redemption delay
+     * @param redemptionDelayInSeconds_ The new redemption delay in seconds
+     * @dev Validation (upper bound, access control) is performed by the caller
+     */
+    function setRedemptionDelay(uint256 redemptionDelayInSeconds_) internal {
+        _getRedemptionDelay().redemptionDelayInSeconds = redemptionDelayInSeconds_;
+    }
+
+    /**
+     * @notice Retrieves the redemption lock start time for an account
+     * @param account_ The address to read the lock start time for
+     * @return The timestamp of the account's last deposit or mint, 0 if the account never deposited
+     */
+    function getRedemptionLockStartTime(address account_) internal view returns (uint256) {
+        return getRedemptionLockStartTimes().lockStartTime[account_];
+    }
+
+    /**
+     * @notice Records the redemption lock start time for an account after deposit or mint operations
+     * @dev Stores block.timestamp unconditionally, even when the redemption delay is currently 0,
+     * so a later increase of the delay applies to this account as well. The effective unlock time
+     * is computed at read time against the current redemption delay.
+     * @param account_ The address to record the redemption lock start time for
      * @custom:security This function helps prevent potential manipulation through quick deposits and withdrawals
      */
-    function setRedemptionLocks(address account_) internal {
-        uint256 redemptionDelay = IIporFusionAccessManager(address(this)).REDEMPTION_DELAY_IN_SECONDS();
-        if (redemptionDelay == 0) {
-            return;
+    function setRedemptionLockStartTime(address account_) internal {
+        getRedemptionLockStartTimes().lockStartTime[account_] = block.timestamp;
+    }
+
+    /**
+     * @notice Retrieves the redemption delay storage pointer
+     * @dev Uses assembly to access the predetermined storage slot
+     * @return redemptionDelay Storage pointer to the redemption delay
+     */
+    function _getRedemptionDelay() private pure returns (RedemptionDelay storage redemptionDelay) {
+        assembly {
+            redemptionDelay.slot := REDEMPTION_DELAY
         }
-        RedemptionLocks storage redemptionLocks = getRedemptionLocks();
-        uint256 redemptionLock = uint256(block.timestamp) + redemptionDelay;
-        redemptionLocks.redemptionLock[account_] = redemptionLock;
-        emit RedemptionDelayForAccountUpdated(account_, redemptionLock);
     }
 }

--- a/contracts/managers/access/RedemptionDelayLib.sol
+++ b/contracts/managers/access/RedemptionDelayLib.sol
@@ -30,21 +30,35 @@ library RedemptionDelayLib {
     error AccountIsLocked(uint256 unlockTime);
 
     /**
-     * @notice Retrieves the lock time for a specific account
-     * @dev Used to check when an account will be able to withdraw or redeem
+     * @notice Emitted when an account's redemption lock is refreshed by a deposit or mint
+     * @param account The address of the affected account
+     * @param redemptionDelay The unlock timestamp effective under the redemption delay at the time of the deposit
+     */
+    event RedemptionDelayForAccountUpdated(address account, uint256 redemptionDelay);
+
+    /**
+     * @notice Retrieves the effective unlock timestamp for a specific account
+     * @dev Computed at read time as lock start time (last deposit/mint) + the current
+     * redemption delay, so every change of the vault-wide delay immediately moves the
+     * unlock time of all accounts, in both directions
      * @param account_ The address to check the lock time for
-     * @return The timestamp until which the account is locked
+     * @return The timestamp until which the account is locked under the current redemption delay,
+     * possibly in the past when the lock has already expired, 0 if the account never deposited
      * @custom:security This value should be checked before allowing withdrawals
      */
     function getAccountLockTime(address account_) internal view returns (uint256) {
-        return IporFusionAccessManagersStorageLib.getRedemptionLocks().redemptionLock[account_];
+        uint256 lockStartTime = IporFusionAccessManagersStorageLib.getRedemptionLockStartTime(account_);
+        if (lockStartTime == 0) {
+            return 0;
+        }
+        return lockStartTime + IporFusionAccessManagersStorageLib.getRedemptionDelay();
     }
 
     /**
      * @notice Enforces redemption delay rules based on function calls
      * @dev Implements the following rules:
-     * 1. For withdrawals/redemptions: Checks if the account is still locked
-     * 2. For deposits/mints: Sets a new lock period
+     * 1. For withdrawals/redemptions/transfers: Checks if the account is still locked under the current delay
+     * 2. For deposits/mints: Records the lock start time
      * @param account_ The account performing the operation
      * @param sig_ The function selector of the operation being performed
      * @custom:security Critical function that prevents quick deposit/withdrawal cycles
@@ -57,12 +71,13 @@ library RedemptionDelayLib {
             sig_ == TRANSFER_FROM_SELECTOR ||
             sig_ == TRANSFER_SELECTOR
         ) {
-            uint256 unlockTime = IporFusionAccessManagersStorageLib.getRedemptionLocks().redemptionLock[account_];
+            uint256 unlockTime = getAccountLockTime(account_);
             if (unlockTime > block.timestamp) {
                 revert AccountIsLocked(unlockTime);
             }
         } else if (sig_ == DEPOSIT_SELECTOR || sig_ == MINT_SELECTOR || sig_ == DEPOSIT_WITH_PERMIT_SELECTOR) {
-            IporFusionAccessManagersStorageLib.setRedemptionLocks(account_);
+            IporFusionAccessManagersStorageLib.setRedemptionLockStartTime(account_);
+            emit RedemptionDelayForAccountUpdated(account_, getAccountLockTime(account_));
         }
     }
 }

--- a/contracts/managers/pause/PlasmaVaultPauser.sol
+++ b/contracts/managers/pause/PlasmaVaultPauser.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.30;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {IAccessManaged} from "@openzeppelin/contracts/access/manager/IAccessManaged.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import {IIporFusionAccessManager} from "../../interfaces/IIporFusionAccessManager.sol";
+import {Errors} from "../../libraries/errors/Errors.sol";
+
+/**
+ * @title PlasmaVaultPauser
+ * @author IPOR Labs
+ * @notice Emergency pause contract for IPOR Fusion Plasma Vaults. Allows whitelisted accounts to pause
+ * a given Plasma Vault by closing it on its IporFusionAccessManager (authority).
+ * @dev The contract is intentionally minimal and NOT upgradeable:
+ * - The only action it can ever perform on a vault is `updateTargetClosed(vault, true)` on the vault's
+ *   IporFusionAccessManager. The function selector and the `closed = true` flag are hard-coded, so this
+ *   contract can pause a vault but can never reopen it, nor call any other restricted function.
+ * - Reopening a paused vault must be performed directly on the IporFusionAccessManager by an account
+ *   with the GUARDIAN_ROLE.
+ *
+ * Access control:
+ * - Ownership follows the two-step pattern (Ownable2Step). The initial owner is set in the constructor,
+ *   when the zero address is provided the deployer becomes the owner.
+ * - `renounceOwnership` is disabled to prevent accidentally leaving the whitelist unmanageable.
+ * - The owner manages a per-vault whitelist: an account is whitelisted for a specific vault and can
+ *   pause only that vault.
+ * - The whitelist is enumerable in both directions: accounts whitelisted for a given vault and vaults
+ *   assigned to a given account can be listed on-chain without external indexing. Count and paginated
+ *   getters are provided for sets too large to be read in a single call.
+ * - Global registries of all configured vaults and all configured accounts are enumerable as well,
+ *   an entry stays listed while it has at least one active whitelist assignment.
+ *
+ * Function permissions:
+ * - pause: Restricted to accounts whitelisted for the given vault
+ * - addToWhitelist: Restricted to the owner
+ * - removeFromWhitelist: Restricted to the owner
+ *
+ * Integration requirements:
+ * - This contract must be granted the GUARDIAN_ROLE (or any role authorized to call `updateTargetClosed`)
+ *   on the IporFusionAccessManager of every vault it is expected to pause, with execution delay set to 0.
+ * - Vault addresses added to the whitelist are trusted IPOR Fusion Plasma Vaults, curated by the owner.
+ *
+ * Security features:
+ * - Per-vault whitelist prevents a compromised pauser account from pausing unrelated vaults
+ * - Post-condition check verifies the vault is effectively closed on the access manager
+ * - One-way action (pause only) limits the blast radius of a compromised pauser account
+ */
+contract PlasmaVaultPauser is Ownable2Step {
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    /// @notice Emitted when an account is added to the whitelist of a given vault
+    /// @param vault The vault for which the account is whitelisted
+    /// @param account The account allowed to pause the vault
+    event AddressAddedToWhitelist(address vault, address account);
+
+    /// @notice Emitted when an account is removed from the whitelist of a given vault
+    /// @param vault The vault for which the account is removed
+    /// @param account The account no longer allowed to pause the vault
+    event AddressRemovedFromWhitelist(address vault, address account);
+
+    /// @notice Emitted when a vault is paused (closed on its access manager)
+    /// @param vault The paused vault
+    /// @param accessManager The IporFusionAccessManager on which the vault was closed
+    /// @param account The whitelisted account that triggered the pause
+    event VaultPaused(address vault, address accessManager, address account);
+
+    /// @notice Thrown when the caller is not whitelisted for the given vault
+    error AccountNotWhitelisted(address vault, address account);
+    /// @notice Thrown when the vault reports a zero address authority
+    error InvalidAuthority(address vault);
+    /// @notice Thrown when the access manager did not close the vault despite a successful call
+    error VaultPauseFailed(address vault);
+    /// @notice Thrown when attempting to renounce ownership, which is disabled
+    error RenounceOwnershipDisabled();
+
+    /// @notice Accounts allowed to pause a given vault, managed by the owner
+    /// @dev vault => set of whitelisted accounts, kept in sync with _whitelistedVaults
+    mapping(address vault => EnumerableSet.AddressSet accounts) private _whitelistedAccounts;
+
+    /// @notice Vaults a given account is allowed to pause, managed by the owner
+    /// @dev account => set of vaults, kept in sync with _whitelistedAccounts
+    mapping(address account => EnumerableSet.AddressSet vaults) private _whitelistedVaults;
+
+    /// @notice All vaults that currently have at least one whitelisted account
+    EnumerableSet.AddressSet private _allVaults;
+
+    /// @notice All accounts that are currently whitelisted for at least one vault
+    EnumerableSet.AddressSet private _allAccounts;
+
+    /// @notice Sets the initial owner of the contract
+    /// @param initialOwner_ The initial owner address, when the zero address is provided the deployer becomes the owner
+    constructor(address initialOwner_) Ownable(initialOwner_ == address(0) ? msg.sender : initialOwner_) {
+        /// @dev Ownership can be transferred later only via the two-step process (Ownable2Step)
+    }
+
+    /**
+     * @notice Pauses the given Plasma Vault by closing it on its IporFusionAccessManager
+     * @param vaultAddress_ The address of the Plasma Vault to pause
+     * @dev Reads the vault's authority (IporFusionAccessManager) and calls `updateTargetClosed(vault, true)`.
+     * Verifies the vault is effectively closed afterwards. This contract cannot reopen the vault.
+     * @custom:access Restricted to accounts whitelisted for the given vault
+     */
+    function pause(address vaultAddress_) external {
+        if (!_whitelistedAccounts[vaultAddress_].contains(msg.sender)) {
+            revert AccountNotWhitelisted(vaultAddress_, msg.sender);
+        }
+
+        address accessManager = IAccessManaged(vaultAddress_).authority();
+
+        if (accessManager == address(0)) {
+            revert InvalidAuthority(vaultAddress_);
+        }
+
+        IIporFusionAccessManager(accessManager).updateTargetClosed(vaultAddress_, true);
+
+        if (!IIporFusionAccessManager(accessManager).isTargetClosed(vaultAddress_)) {
+            revert VaultPauseFailed(vaultAddress_);
+        }
+
+        emit VaultPaused(vaultAddress_, accessManager, msg.sender);
+    }
+
+    /**
+     * @notice Adds an account to the whitelist of a given vault
+     * @param vaultAddress_ The vault for which the account is allowed to call `pause`
+     * @param account_ The account to whitelist
+     * @dev Idempotent - adding an already whitelisted account does not emit an event
+     * @custom:access Restricted to the owner
+     */
+    function addToWhitelist(address vaultAddress_, address account_) external onlyOwner {
+        if (vaultAddress_ == address(0) || account_ == address(0)) {
+            revert Errors.WrongAddress();
+        }
+
+        if (!_whitelistedAccounts[vaultAddress_].add(account_)) {
+            return;
+        }
+
+        _whitelistedVaults[account_].add(vaultAddress_);
+        _allVaults.add(vaultAddress_);
+        _allAccounts.add(account_);
+
+        emit AddressAddedToWhitelist(vaultAddress_, account_);
+    }
+
+    /**
+     * @notice Removes an account from the whitelist of a given vault
+     * @param vaultAddress_ The vault for which the account is no longer allowed to call `pause`
+     * @param account_ The account to remove
+     * @dev Idempotent - removing a not whitelisted account does not emit an event.
+     * The vault and the account are removed from the global registries together with their last assignment.
+     * @custom:access Restricted to the owner
+     */
+    function removeFromWhitelist(address vaultAddress_, address account_) external onlyOwner {
+        if (!_whitelistedAccounts[vaultAddress_].remove(account_)) {
+            return;
+        }
+
+        _whitelistedVaults[account_].remove(vaultAddress_);
+
+        if (_whitelistedAccounts[vaultAddress_].length() == 0) {
+            _allVaults.remove(vaultAddress_);
+        }
+
+        if (_whitelistedVaults[account_].length() == 0) {
+            _allAccounts.remove(account_);
+        }
+
+        emit AddressRemovedFromWhitelist(vaultAddress_, account_);
+    }
+
+    /**
+     * @notice Checks whether an account is whitelisted to pause a given vault
+     * @param vaultAddress_ The vault address
+     * @param account_ The account address
+     * @return True when the account is allowed to call `pause` for the given vault
+     */
+    function isWhitelisted(address vaultAddress_, address account_) external view returns (bool) {
+        return _whitelistedAccounts[vaultAddress_].contains(account_);
+    }
+
+    /**
+     * @notice Returns all accounts whitelisted to pause a given vault
+     * @param vaultAddress_ The vault address
+     * @return Array of whitelisted accounts, order is not guaranteed
+     * @dev Copies the whole set to memory, intended for off-chain reads of small sets.
+     * For large sets use {getWhitelistedAccountsCount} with the paginated variant of this function.
+     */
+    function getWhitelistedAccounts(address vaultAddress_) external view returns (address[] memory) {
+        return _whitelistedAccounts[vaultAddress_].values();
+    }
+
+    /**
+     * @notice Returns the number of accounts whitelisted to pause a given vault
+     * @param vaultAddress_ The vault address
+     * @return Number of whitelisted accounts
+     */
+    function getWhitelistedAccountsCount(address vaultAddress_) external view returns (uint256) {
+        return _whitelistedAccounts[vaultAddress_].length();
+    }
+
+    /**
+     * @notice Returns a page of accounts whitelisted to pause a given vault
+     * @param vaultAddress_ The vault address
+     * @param offset_ Zero-based index of the first account to return
+     * @param limit_ Maximum number of accounts to return
+     * @return Array of at most `limit_` accounts starting at `offset_`, empty when `offset_` is out of range.
+     * Order is not guaranteed but stable between calls as long as the whitelist is not modified.
+     */
+    function getWhitelistedAccounts(
+        address vaultAddress_,
+        uint256 offset_,
+        uint256 limit_
+    ) external view returns (address[] memory) {
+        return _paginate(_whitelistedAccounts[vaultAddress_], offset_, limit_);
+    }
+
+    /**
+     * @notice Returns all vaults a given account is whitelisted to pause
+     * @param account_ The account address
+     * @return Array of vaults, order is not guaranteed
+     * @dev Copies the whole set to memory, intended for off-chain reads of small sets.
+     * For large sets use {getWhitelistedVaultsCount} with the paginated variant of this function.
+     */
+    function getWhitelistedVaults(address account_) external view returns (address[] memory) {
+        return _whitelistedVaults[account_].values();
+    }
+
+    /**
+     * @notice Returns the number of vaults a given account is whitelisted to pause
+     * @param account_ The account address
+     * @return Number of vaults
+     */
+    function getWhitelistedVaultsCount(address account_) external view returns (uint256) {
+        return _whitelistedVaults[account_].length();
+    }
+
+    /**
+     * @notice Returns a page of vaults a given account is whitelisted to pause
+     * @param account_ The account address
+     * @param offset_ Zero-based index of the first vault to return
+     * @param limit_ Maximum number of vaults to return
+     * @return Array of at most `limit_` vaults starting at `offset_`, empty when `offset_` is out of range.
+     * Order is not guaranteed but stable between calls as long as the whitelist is not modified.
+     */
+    function getWhitelistedVaults(
+        address account_,
+        uint256 offset_,
+        uint256 limit_
+    ) external view returns (address[] memory) {
+        return _paginate(_whitelistedVaults[account_], offset_, limit_);
+    }
+
+    /**
+     * @notice Returns all vaults that currently have at least one whitelisted account
+     * @return Array of vaults, order is not guaranteed
+     * @dev Copies the whole set to memory, intended for off-chain reads of small sets.
+     * For large sets use {getVaultsCount} with the paginated variant of this function.
+     */
+    function getVaults() external view returns (address[] memory) {
+        return _allVaults.values();
+    }
+
+    /**
+     * @notice Returns the number of vaults that currently have at least one whitelisted account
+     * @return Number of configured vaults
+     */
+    function getVaultsCount() external view returns (uint256) {
+        return _allVaults.length();
+    }
+
+    /**
+     * @notice Returns a page of vaults that currently have at least one whitelisted account
+     * @param offset_ Zero-based index of the first vault to return
+     * @param limit_ Maximum number of vaults to return
+     * @return Array of at most `limit_` vaults starting at `offset_`, empty when `offset_` is out of range.
+     * Order is not guaranteed but stable between calls as long as the whitelist is not modified.
+     */
+    function getVaults(uint256 offset_, uint256 limit_) external view returns (address[] memory) {
+        return _paginate(_allVaults, offset_, limit_);
+    }
+
+    /**
+     * @notice Returns all accounts that are currently whitelisted for at least one vault
+     * @return Array of accounts, order is not guaranteed
+     * @dev Copies the whole set to memory, intended for off-chain reads of small sets.
+     * For large sets use {getAccountsCount} with the paginated variant of this function.
+     */
+    function getAccounts() external view returns (address[] memory) {
+        return _allAccounts.values();
+    }
+
+    /**
+     * @notice Returns the number of accounts that are currently whitelisted for at least one vault
+     * @return Number of configured accounts
+     */
+    function getAccountsCount() external view returns (uint256) {
+        return _allAccounts.length();
+    }
+
+    /**
+     * @notice Returns a page of accounts that are currently whitelisted for at least one vault
+     * @param offset_ Zero-based index of the first account to return
+     * @param limit_ Maximum number of accounts to return
+     * @return Array of at most `limit_` accounts starting at `offset_`, empty when `offset_` is out of range.
+     * Order is not guaranteed but stable between calls as long as the whitelist is not modified.
+     */
+    function getAccounts(uint256 offset_, uint256 limit_) external view returns (address[] memory) {
+        return _paginate(_allAccounts, offset_, limit_);
+    }
+
+    /**
+     * @notice Renouncing ownership is disabled
+     * @dev Prevents accidentally leaving the whitelist unmanageable. Ownership can only be moved
+     * via the two-step transfer process.
+     */
+    function renounceOwnership() public view override onlyOwner {
+        revert RenounceOwnershipDisabled();
+    }
+
+    /// @dev Returns at most `limit_` elements of the set starting at `offset_`
+    function _paginate(
+        EnumerableSet.AddressSet storage set_,
+        uint256 offset_,
+        uint256 limit_
+    ) private view returns (address[] memory page) {
+        uint256 total = set_.length();
+
+        if (offset_ >= total) {
+            return new address[](0);
+        }
+
+        uint256 size = total - offset_;
+        if (size > limit_) {
+            size = limit_;
+        }
+
+        page = new address[](size);
+        for (uint256 i; i < size; ++i) {
+            page[i] = set_.at(offset_ + i);
+        }
+    }
+}

--- a/contracts/vaults/PlasmaVaultGovernance.sol
+++ b/contracts/vaults/PlasmaVaultGovernance.sol
@@ -1618,6 +1618,38 @@ abstract contract PlasmaVaultGovernance is IPlasmaVaultGovernance, AccessManaged
         IIporFusionAccessManager(authority()).setMinimalExecutionDelaysForRoles(rolesIds_, delays_);
     }
 
+    /// @notice Sets the vault-wide redemption delay
+    /// @dev Forwards to IporFusionAccessManager.setRedemptionDelay, which the access manager exposes only to the
+    /// TECH_PLASMA_VAULT_ROLE held by this vault. The owner-facing entry point lives on the vault on purpose:
+    /// OpenZeppelin AccessManager cannot schedule or execute its own custom functions (schedule/execute recognise
+    /// only the built-in admin selectors when the target is the manager itself), so a setter restricted directly
+    /// on the access manager could never be put behind the OWNER_ROLE execution delay. Routing the call through
+    /// the vault makes it subject to the same timelock (schedule -> wait -> execute, cancellable by the
+    /// GUARDIAN_ROLE) as every other governance function.
+    ///
+    /// Redemption Delay Semantics:
+    /// - Cooling period between an account's deposit/mint and its withdraw/redeem/transfer
+    /// - The new value governs every account immediately, measured from each account's own last deposit
+    /// - Lowering the delay releases existing depositors, raising it extends their locks
+    /// - Capped at IporFusionAccessManager.MAX_REDEMPTION_DELAY_IN_SECONDS
+    ///
+    /// Security Considerations:
+    /// - Only callable by OWNER_ROLE
+    /// - Subject to the OWNER_ROLE execution delay when one is configured
+    /// - Reverts with TooLongRedemptionDelay above the maximum
+    ///
+    /// Related Components:
+    /// - IporFusionAccessManager
+    /// - RedemptionDelayLib
+    /// - Access Control System
+    ///
+    /// @param redemptionDelayInSeconds_ The new redemption delay in seconds
+    /// @custom:access OWNER_ROLE restricted
+    /// @custom:security Critical for depositor lock semantics, timelock enforced through the vault
+    function setRedemptionDelay(uint256 redemptionDelayInSeconds_) external override restricted {
+        IIporFusionAccessManager(authority()).setRedemptionDelay(redemptionDelayInSeconds_);
+    }
+
     /// @notice Sets or updates pre-hook implementations for function selectors
     /// @dev Manages the configuration of pre-execution hooks through PreHooksLib
     ///

--- a/contracts/vaults/initializers/IporFusionAccessManagerInitializerLibV1.sol
+++ b/contracts/vaults/initializers/IporFusionAccessManagerInitializerLibV1.sol
@@ -5,7 +5,12 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {IPlasmaVault} from "../../interfaces/IPlasmaVault.sol";
 import {AccessManager} from "@openzeppelin/contracts/access/manager/AccessManager.sol";
-import {RoleToFunction, AdminRole, AccountToRole, InitializationData} from "../../managers/access/IporFusionAccessManagerInitializationLib.sol";
+import {
+    RoleToFunction,
+    AdminRole,
+    AccountToRole,
+    InitializationData
+} from "../../managers/access/IporFusionAccessManagerInitializationLib.sol";
 import {PlasmaVaultGovernance} from "../PlasmaVaultGovernance.sol";
 import {PlasmaVaultBase} from "../PlasmaVaultBase.sol";
 import {Roles} from "../../libraries/Roles.sol";
@@ -87,7 +92,7 @@ library IporFusionAccessManagerInitializerLibV1 {
     error InvalidAddress();
 
     uint256 private constant ADMIN_ROLES_ARRAY_LENGTH = 20;
-    uint256 private constant ROLES_TO_FUNCTION_INITIAL_ARRAY_LENGTH = 39;
+    uint256 private constant ROLES_TO_FUNCTION_INITIAL_ARRAY_LENGTH = 41;
     uint256 private constant ROLES_TO_FUNCTION_CLAIM_MANAGER = 8;
     uint256 private constant ROLES_TO_FUNCTION_WITHDRAW_MANAGER = 7;
     uint256 private constant ROLES_TO_FUNCTION_FEE_MANAGER = 6;
@@ -768,10 +773,26 @@ library IporFusionAccessManagerInitializerLibV1 {
             minimalExecutionDelay: 0
         });
 
+        /// @dev Only the vault (TECH_PLASMA_VAULT_ROLE) writes the redemption delay on the access manager - the
+        /// owner-facing entry point is PlasmaVaultGovernance.setRedemptionDelay below, so the OWNER_ROLE timelock applies
+        rolesToFunction[_next(iterator)] = RoleToFunction({
+            target: plasmaVaultAddress_.accessManager,
+            roleId: Roles.TECH_PLASMA_VAULT_ROLE,
+            functionSelector: IporFusionAccessManager.setRedemptionDelay.selector,
+            minimalExecutionDelay: 0
+        });
+
         rolesToFunction[_next(iterator)] = RoleToFunction({
             target: plasmaVaultAddress_.plasmaVault,
             roleId: Roles.OWNER_ROLE,
             functionSelector: PlasmaVaultGovernance.setMinimalExecutionDelaysForRoles.selector,
+            minimalExecutionDelay: 0
+        });
+
+        rolesToFunction[_next(iterator)] = RoleToFunction({
+            target: plasmaVaultAddress_.plasmaVault,
+            roleId: Roles.OWNER_ROLE,
+            functionSelector: PlasmaVaultGovernance.setRedemptionDelay.selector,
             minimalExecutionDelay: 0
         });
 

--- a/test/RoleLib.sol
+++ b/test/RoleLib.sol
@@ -183,11 +183,12 @@ library RoleLib {
         address plasmaVault_,
         IporFusionAccessManager accessManager_
     ) private {
-        bytes4[] memory plasmaVaultRoles = new bytes4[](4);
+        bytes4[] memory plasmaVaultRoles = new bytes4[](5);
         plasmaVaultRoles[0] = IporFusionAccessManager.convertToPublicVault.selector;
         plasmaVaultRoles[1] = IporFusionAccessManager.enableTransferShares.selector;
         plasmaVaultRoles[2] = IporFusionAccessManager.setMinimalExecutionDelaysForRoles.selector;
         plasmaVaultRoles[3] = IporFusionAccessManager.canCallAndUpdate.selector;
+        plasmaVaultRoles[4] = IporFusionAccessManager.setRedemptionDelay.selector;
 
         vm_.prank(usersWithRoles_.superAdmin);
         accessManager_.setTargetFunctionRole(address(accessManager_), plasmaVaultRoles, Roles.TECH_PLASMA_VAULT_ROLE);
@@ -198,8 +199,9 @@ library RoleLib {
         vm_.prank(usersWithRoles_.superAdmin);
         accessManager_.setTargetFunctionRole(address(accessManager_), guardianSig, Roles.GUARDIAN_ROLE);
 
-        bytes4[] memory ownerSig = new bytes4[](1);
+        bytes4[] memory ownerSig = new bytes4[](2);
         ownerSig[0] = PlasmaVaultGovernance.setMinimalExecutionDelaysForRoles.selector;
+        ownerSig[1] = PlasmaVaultGovernance.setRedemptionDelay.selector;
 
         vm_.prank(usersWithRoles_.superAdmin);
         accessManager_.setTargetFunctionRole(plasmaVault_, ownerSig, Roles.OWNER_ROLE);

--- a/test/factory/FusionFactory.t.sol
+++ b/test/factory/FusionFactory.t.sol
@@ -571,6 +571,90 @@ contract FusionFactoryTest is Test {
         assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), 0);
     }
 
+    function testShouldOwnerChangeRedemptionDelayAfterVaultCreation() public {
+        // given
+        uint256 redemptionDelay = 123;
+
+        FusionFactoryLogicLib.FusionInstance memory instance = fusionFactory.clone(
+            "Test Asset",
+            "TEST",
+            address(underlyingToken),
+            redemptionDelay,
+            owner,
+            0
+        );
+
+        IporFusionAccessManager accessManager = IporFusionAccessManager(instance.accessManager);
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), redemptionDelay);
+
+        // when - the owner changes the delay through the vault's governance entry point
+        vm.prank(owner);
+        IPlasmaVaultGovernance(instance.plasmaVault).setRedemptionDelay(0);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), 0);
+
+        // when
+        vm.prank(owner);
+        IPlasmaVaultGovernance(instance.plasmaVault).setRedemptionDelay(7 days);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), 7 days);
+    }
+
+    function testShouldNotChangeRedemptionDelayDirectlyOnAccessManagerEvenWhenOwner() public {
+        // given - the access manager setter is reserved for the vault (TECH_PLASMA_VAULT_ROLE), the owner must go
+        // through PlasmaVaultGovernance.setRedemptionDelay so the OWNER_ROLE timelock can apply
+        uint256 redemptionDelay = 123;
+
+        FusionFactoryLogicLib.FusionInstance memory instance = fusionFactory.clone(
+            "Test Asset",
+            "TEST",
+            address(underlyingToken),
+            redemptionDelay,
+            owner,
+            0
+        );
+
+        IporFusionAccessManager accessManager = IporFusionAccessManager(instance.accessManager);
+
+        // when
+        vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", owner));
+        vm.prank(owner);
+        accessManager.setRedemptionDelay(0);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), redemptionDelay);
+    }
+
+    function testShouldNotChangeRedemptionDelayAfterVaultCreationWhenNotOwner() public {
+        // given
+        uint256 redemptionDelay = 123;
+
+        FusionFactoryLogicLib.FusionInstance memory instance = fusionFactory.clone(
+            "Test Asset",
+            "TEST",
+            address(underlyingToken),
+            redemptionDelay,
+            owner,
+            0
+        );
+
+        IporFusionAccessManager accessManager = IporFusionAccessManager(instance.accessManager);
+
+        // when
+        vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", adminOne));
+        vm.prank(adminOne);
+        IPlasmaVaultGovernance(instance.plasmaVault).setRedemptionDelay(0);
+
+        vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", adminOne));
+        vm.prank(adminOne);
+        accessManager.setRedemptionDelay(0);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), redemptionDelay);
+    }
+
     function testShouldCreateVaultWithCorrectWithdrawWindow() public {
         // given
         uint256 redemptionDelay = 1 seconds;
@@ -890,7 +974,6 @@ contract FusionFactoryTest is Test {
         assertTrue(instance.rewardsManager != address(0));
         assertTrue(instance.contextManager != address(0));
         assertTrue(instance.feeManager != address(0));
-
     }
 
     function testShouldRevertUpgradeWhenNotOwner() public {
@@ -1755,14 +1838,7 @@ contract FusionFactoryTest is Test {
 
         // when / then
         vm.expectRevert(abi.encodeWithSelector(FusionFactoryLib.DaoFeePackageIndexOutOfBounds.selector, 10, 2));
-        fusionFactory.clone(
-            "Test Asset",
-            "TEST",
-            address(underlyingToken),
-            redemptionDelay,
-            owner,
-            10
-        );
+        fusionFactory.clone("Test Asset", "TEST", address(underlyingToken), redemptionDelay, owner, 10);
     }
 
     function testShouldRevertWhenCloneWithInvalidDaoFeePackageIndex() public {
@@ -1771,14 +1847,7 @@ contract FusionFactoryTest is Test {
 
         // when / then
         vm.expectRevert(abi.encodeWithSelector(FusionFactoryLogicLib.DaoFeePackageIndexOutOfBounds.selector, 10, 2));
-        fusionFactory.clone(
-            "Test Asset",
-            "TEST",
-            address(underlyingToken),
-            redemptionDelay,
-            owner,
-            10
-        );
+        fusionFactory.clone("Test Asset", "TEST", address(underlyingToken), redemptionDelay, owner, 10);
     }
 
     function testShouldCreateVaultWithDifferentDaoFeePackages() public {

--- a/test/libraries/FusionStorageSlotsTest.t.sol
+++ b/test/libraries/FusionStorageSlotsTest.t.sol
@@ -20,10 +20,16 @@ contract FusionStorageSlotsTest is Test {
     // IporFusionAccessManagersStorageLib
     // ============================================
 
-    function testAccessManager_RedemptionLocksSlot() public pure {
-        bytes32 expected = _computeSlot("io.ipor.managers.access.RedemptionLocks");
-        bytes32 actual = 0x5e07febb5bd598f6b55406c9bf939d497fd39a2dbc2b5891f20f6640c3f32500;
-        assertEq(actual, expected, "REDEMPTION_LOCKS mismatch");
+    function testAccessManager_RedemptionLockStartTimesSlot() public pure {
+        bytes32 expected = _computeSlot("io.ipor.managers.access.RedemptionLockStartTimes");
+        bytes32 actual = 0x83e7bafd2a5059a7a3f8f00883c599ce24355cc422725b4bf7e796d03c954a00;
+        assertEq(actual, expected, "REDEMPTION_LOCK_START_TIMES mismatch");
+    }
+
+    function testAccessManager_RedemptionDelaySlot() public pure {
+        bytes32 expected = _computeSlot("io.ipor.managers.access.RedemptionDelay");
+        bytes32 actual = 0x145eef5574c3cce4d2653445e6a5a4d0b02eafca2d8fced992bac1eca819d500;
+        assertEq(actual, expected, "REDEMPTION_DELAY mismatch");
     }
 
     function testAccessManager_MinimalExecutionDelayForRoleSlot() public pure {

--- a/test/managers/PlasmaVaultPauserForkTest.t.sol
+++ b/test/managers/PlasmaVaultPauserForkTest.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IAccessManaged} from "@openzeppelin/contracts/access/manager/IAccessManaged.sol";
+import {PlasmaVaultPauser} from "../../contracts/managers/pause/PlasmaVaultPauser.sol";
+import {IporFusionAccessManager} from "../../contracts/managers/access/IporFusionAccessManager.sol";
+import {PlasmaVault} from "../../contracts/vaults/PlasmaVault.sol";
+import {Roles} from "../../contracts/libraries/Roles.sol";
+
+/// @dev Fork e2e on Base mainnet against the PRODUCTION IPOR USDC Lending Optimizer vault.
+/// The pauser is wired exactly as it would be in production: the OWNER_ROLE holder (DAO Safe,
+/// admin of GUARDIAN_ROLE, execution delay 0) grants GUARDIAN_ROLE to the pauser contract.
+/// Verified live at FORK_BLOCK: getRoleAdmin(GUARDIAN_ROLE) == OWNER_ROLE,
+/// getMinimalExecutionDelayForRole(GUARDIAN_ROLE) == 0, deposit mapped to PUBLIC_ROLE,
+/// REDEMPTION_DELAY_IN_SECONDS == 1.
+contract PlasmaVaultPauserForkTest is Test {
+    /// @dev IPOR Fusion USDC Lending Optimizer (Base mainnet)
+    address internal constant VAULT = 0x45aa96f0b3188D47a1DaFdbefCE1db6B37f58216;
+    address internal constant ACCESS_MANAGER = 0x051F90A809d8Bf16e61514F8035C8bc644508a81;
+    /// @dev DAO Safe - holds OWNER_ROLE (the admin role of GUARDIAN_ROLE) with execution delay 0
+    address internal constant DAO_SAFE = 0xF6a9bd8F6DC537675D499Ac1CA14f2c55d8b5569;
+    /// @dev Vault underlying - native Circle USDC on Base
+    address internal constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+
+    uint256 internal constant FORK_BLOCK = 49_875_613;
+    uint256 internal constant DEPOSIT_AMOUNT = 1_000e6;
+
+    PlasmaVaultPauser internal pauser;
+    IporFusionAccessManager internal accessManager;
+
+    address internal owner;
+    address internal guardian;
+    address internal user;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("BASE_PROVIDER_URL"), FORK_BLOCK);
+
+        accessManager = IporFusionAccessManager(ACCESS_MANAGER);
+
+        owner = makeAddr("owner");
+        guardian = makeAddr("guardian");
+        user = makeAddr("user");
+
+        pauser = new PlasmaVaultPauser(owner);
+
+        /// @dev production wiring: the OWNER_ROLE holder grants GUARDIAN_ROLE to the pauser contract
+        vm.prank(DAO_SAFE);
+        accessManager.grantRole(Roles.GUARDIAN_ROLE, address(pauser), 0);
+
+        (bool isMember, uint32 executionDelay) = accessManager.hasRole(Roles.GUARDIAN_ROLE, address(pauser));
+        assertTrue(isMember, "pauser should have GUARDIAN_ROLE");
+        assertEq(executionDelay, 0, "pauser should act without execution delay");
+
+        vm.prank(owner);
+        pauser.addToWhitelist(VAULT, guardian);
+    }
+
+    function testShouldPauseProductionVaultOnBaseFork() public {
+        // given - the production vault is open, deposit and redeem work
+        assertFalse(accessManager.isTargetClosed(VAULT), "vault should be open before pause");
+
+        deal(USDC, user, 2 * DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        IERC20(USDC).approve(VAULT, 2 * DEPOSIT_AMOUNT);
+        uint256 shares = PlasmaVault(VAULT).deposit(2 * DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+        assertGt(shares, 0, "deposit should work before pause");
+
+        /// @dev skip the 1-second redemption delay of this vault
+        vm.warp(block.timestamp + 2);
+
+        vm.prank(user);
+        PlasmaVault(VAULT).redeem(shares / 2, user, user);
+        assertGt(IERC20(USDC).balanceOf(user), 0, "redeem should work before pause");
+
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit PlasmaVaultPauser.VaultPaused(VAULT, ACCESS_MANAGER, guardian);
+        vm.prank(guardian);
+        pauser.pause(VAULT);
+
+        // then - the vault is closed on its access manager...
+        assertTrue(accessManager.isTargetClosed(VAULT), "vault should be closed after pause");
+
+        // ...deposits are blocked...
+        vm.expectRevert(abi.encodeWithSelector(IAccessManaged.AccessManagedUnauthorized.selector, user));
+        vm.prank(user);
+        PlasmaVault(VAULT).deposit(DEPOSIT_AMOUNT, user);
+
+        // ...and redemptions are blocked as well
+        vm.expectRevert(abi.encodeWithSelector(IAccessManaged.AccessManagedUnauthorized.selector, user));
+        vm.prank(user);
+        PlasmaVault(VAULT).redeem(shares / 2, user, user);
+    }
+
+    function testShouldNotPauseProductionVaultWhenNotWhitelisted() public {
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(PlasmaVaultPauser.AccountNotWhitelisted.selector, VAULT, user));
+        vm.prank(user);
+        pauser.pause(VAULT);
+
+        assertFalse(accessManager.isTargetClosed(VAULT), "vault should stay open");
+    }
+
+    function testShouldNotPauseProductionVaultWhenPauserHasNoGuardianRole() public {
+        // given - a pauser which was never granted GUARDIAN_ROLE on the production access manager
+        vm.startPrank(owner);
+        PlasmaVaultPauser pauserWithoutRole = new PlasmaVaultPauser(owner);
+        pauserWithoutRole.addToWhitelist(VAULT, guardian);
+        vm.stopPrank();
+
+        // when / then
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IporFusionAccessManager.AccessManagedUnauthorized.selector,
+                address(pauserWithoutRole)
+            )
+        );
+        vm.prank(guardian);
+        pauserWithoutRole.pause(VAULT);
+
+        assertFalse(accessManager.isTargetClosed(VAULT), "vault should stay open");
+    }
+
+    function testShouldGuardianReopenProductionVaultAfterPause() public {
+        // given
+        vm.prank(guardian);
+        pauser.pause(VAULT);
+        assertTrue(accessManager.isTargetClosed(VAULT), "vault should be closed after pause");
+
+        address humanGuardian = makeAddr("humanGuardian");
+        vm.prank(DAO_SAFE);
+        accessManager.grantRole(Roles.GUARDIAN_ROLE, humanGuardian, 0);
+
+        // when - reopening happens directly on the access manager, the pauser cannot do it
+        vm.prank(humanGuardian);
+        accessManager.updateTargetClosed(VAULT, false);
+
+        // then - the vault is open and accepts deposits again
+        assertFalse(accessManager.isTargetClosed(VAULT), "vault should be reopened by the guardian");
+
+        deal(USDC, user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        IERC20(USDC).approve(VAULT, DEPOSIT_AMOUNT);
+        uint256 shares = PlasmaVault(VAULT).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+        assertGt(shares, 0, "deposit should work after reopening");
+    }
+}

--- a/test/managers/PlasmaVaultPauserTest.t.sol
+++ b/test/managers/PlasmaVaultPauserTest.t.sol
@@ -1,0 +1,910 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.30;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {PlasmaVaultPauser} from "../../contracts/managers/pause/PlasmaVaultPauser.sol";
+import {IporFusionAccessManager} from "../../contracts/managers/access/IporFusionAccessManager.sol";
+import {IIporFusionAccessManager} from "../../contracts/interfaces/IIporFusionAccessManager.sol";
+import {Roles} from "../../contracts/libraries/Roles.sol";
+import {Errors} from "../../contracts/libraries/errors/Errors.sol";
+
+/// @dev Minimal vault mock exposing the AccessManaged authority() getter used by the pauser
+contract MockAccessManagedVault {
+    address private _authority;
+
+    constructor(address authority_) {
+        _authority = authority_;
+    }
+
+    function authority() external view returns (address) {
+        return _authority;
+    }
+
+    function setAuthority(address authority_) external {
+        _authority = authority_;
+    }
+}
+
+/// @dev Access manager mock recording updateTargetClosed calls
+contract MockAccessManager {
+    address public lastTarget;
+    bool public lastClosed;
+    uint256 public updateTargetClosedCallCount;
+
+    mapping(address target => bool closed) public closedTargets;
+
+    function updateTargetClosed(address target_, bool closed_) external {
+        lastTarget = target_;
+        lastClosed = closed_;
+        updateTargetClosedCallCount++;
+        closedTargets[target_] = closed_;
+    }
+
+    function isTargetClosed(address target_) external view returns (bool) {
+        return closedTargets[target_];
+    }
+}
+
+/// @dev Access manager mock which accepts updateTargetClosed but never closes the target
+contract MockSilentAccessManager {
+    function updateTargetClosed(address target_, bool closed_) external {
+        // intentionally does not close the target
+    }
+
+    function isTargetClosed(address) external pure returns (bool) {
+        return false;
+    }
+}
+
+contract PlasmaVaultPauserTest is Test {
+    PlasmaVaultPauser internal pauser;
+    MockAccessManager internal accessManager;
+    MockAccessManagedVault internal vault;
+    MockAccessManagedVault internal vaultB;
+
+    address internal owner;
+    address internal newOwner;
+    address internal guardian;
+    address internal user;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        newOwner = makeAddr("newOwner");
+        guardian = makeAddr("guardian");
+        user = makeAddr("user");
+
+        pauser = new PlasmaVaultPauser(owner);
+
+        accessManager = new MockAccessManager();
+        vault = new MockAccessManagedVault(address(accessManager));
+        vaultB = new MockAccessManagedVault(address(accessManager));
+    }
+
+    //
+    // Ownership - Ownable2Step
+    //
+
+    function testShouldSetProvidedAddressAsOwner() public {
+        // then - setUp deployed the pauser with the owner address provided explicitly
+        assertEq(pauser.owner(), owner, "provided address should be the owner");
+        assertEq(pauser.pendingOwner(), address(0), "pending owner should be empty");
+    }
+
+    function testShouldSetDeployerAsOwnerWhenZeroAddressProvided() public {
+        // when
+        vm.prank(user);
+        PlasmaVaultPauser newPauser = new PlasmaVaultPauser(address(0));
+
+        // then
+        assertEq(newPauser.owner(), user, "deployer should be the owner when zero address is provided");
+    }
+
+    function testShouldStartTwoStepOwnershipTransfer() public {
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit Ownable2Step.OwnershipTransferStarted(owner, newOwner);
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+
+        // then
+        assertEq(pauser.owner(), owner, "owner should not change before acceptance");
+        assertEq(pauser.pendingOwner(), newOwner, "pending owner should be set");
+    }
+
+    function testShouldCompleteTwoStepOwnershipTransfer() public {
+        // given
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit Ownable.OwnershipTransferred(owner, newOwner);
+        vm.prank(newOwner);
+        pauser.acceptOwnership();
+
+        // then
+        assertEq(pauser.owner(), newOwner, "new owner should be set after acceptance");
+        assertEq(pauser.pendingOwner(), address(0), "pending owner should be cleared");
+    }
+
+    function testShouldNotTransferOwnershipWhenNotOwner() public {
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        pauser.transferOwnership(newOwner);
+    }
+
+    function testShouldNotAcceptOwnershipWhenNotPendingOwner() public {
+        // given
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        pauser.acceptOwnership();
+    }
+
+    function testShouldOverridePendingOwnerBeforeAcceptance() public {
+        // given
+        address anotherOwner = makeAddr("anotherOwner");
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+
+        // when
+        vm.prank(owner);
+        pauser.transferOwnership(anotherOwner);
+
+        // then - the first pending owner cannot accept anymore
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, newOwner));
+        vm.prank(newOwner);
+        pauser.acceptOwnership();
+
+        vm.prank(anotherOwner);
+        pauser.acceptOwnership();
+        assertEq(pauser.owner(), anotherOwner, "second pending owner should become the owner");
+    }
+
+    function testShouldCancelOwnershipTransferBySettingPendingOwnerToZero() public {
+        // given
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+
+        // when
+        vm.prank(owner);
+        pauser.transferOwnership(address(0));
+
+        // then
+        assertEq(pauser.pendingOwner(), address(0), "pending owner should be cleared");
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, newOwner));
+        vm.prank(newOwner);
+        pauser.acceptOwnership();
+        assertEq(pauser.owner(), owner, "owner should not change");
+    }
+
+    function testShouldKeepOwnerRightsUntilTransferAccepted() public {
+        // given
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+
+        // when - current owner still manages the whitelist
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        assertTrue(pauser.isWhitelisted(address(vault), guardian), "owner should still manage the whitelist");
+
+        // and - pending owner has no rights yet
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, newOwner));
+        vm.prank(newOwner);
+        pauser.addToWhitelist(address(vault), user);
+    }
+
+    function testShouldNewOwnerManageWhitelistAfterTransfer() public {
+        // given
+        vm.prank(owner);
+        pauser.transferOwnership(newOwner);
+        vm.prank(newOwner);
+        pauser.acceptOwnership();
+
+        // when
+        vm.prank(newOwner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        assertTrue(pauser.isWhitelisted(address(vault), guardian), "new owner should manage the whitelist");
+
+        // and - previous owner lost the rights
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, owner));
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), user);
+    }
+
+    function testShouldNotRenounceOwnership() public {
+        // when / then
+        vm.expectRevert(PlasmaVaultPauser.RenounceOwnershipDisabled.selector);
+        vm.prank(owner);
+        pauser.renounceOwnership();
+
+        assertEq(pauser.owner(), owner, "owner should not change");
+    }
+
+    function testShouldNotRenounceOwnershipWhenNotOwner() public {
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        pauser.renounceOwnership();
+    }
+
+    //
+    // Whitelist management
+    //
+
+    function testShouldAddToWhitelist() public {
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit PlasmaVaultPauser.AddressAddedToWhitelist(address(vault), guardian);
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        assertTrue(pauser.isWhitelisted(address(vault), guardian), "account should be whitelisted");
+    }
+
+    function testShouldRemoveFromWhitelist() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit PlasmaVaultPauser.AddressRemovedFromWhitelist(address(vault), guardian);
+        vm.prank(owner);
+        pauser.removeFromWhitelist(address(vault), guardian);
+
+        // then
+        assertFalse(pauser.isWhitelisted(address(vault), guardian), "account should not be whitelisted");
+    }
+
+    function testShouldNotAddToWhitelistWhenNotOwner() public {
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        assertFalse(pauser.isWhitelisted(address(vault), guardian), "account should not be whitelisted");
+    }
+
+    function testShouldNotRemoveFromWhitelistWhenNotOwner() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, user));
+        vm.prank(user);
+        pauser.removeFromWhitelist(address(vault), guardian);
+
+        assertTrue(pauser.isWhitelisted(address(vault), guardian), "account should stay whitelisted");
+    }
+
+    function testShouldNotAddToWhitelistWhenVaultZeroAddress() public {
+        // when / then
+        vm.expectRevert(Errors.WrongAddress.selector);
+        vm.prank(owner);
+        pauser.addToWhitelist(address(0), guardian);
+    }
+
+    function testShouldNotAddToWhitelistWhenAccountZeroAddress() public {
+        // when / then
+        vm.expectRevert(Errors.WrongAddress.selector);
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), address(0));
+    }
+
+    function testShouldNotEmitEventWhenAddingAlreadyWhitelistedAccount() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when
+        vm.recordLogs();
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event should be emitted on redundant add");
+        assertTrue(pauser.isWhitelisted(address(vault), guardian), "account should stay whitelisted");
+        assertEq(pauser.getWhitelistedAccounts(address(vault)).length, 1, "accounts set should have no duplicates");
+        assertEq(pauser.getWhitelistedVaults(guardian).length, 1, "vaults set should have no duplicates");
+        assertEq(pauser.getVaultsCount(), 1, "global vaults list should have no duplicates");
+        assertEq(pauser.getAccountsCount(), 1, "global accounts list should have no duplicates");
+    }
+
+    function testShouldNotEmitEventWhenRemovingNotWhitelistedAccount() public {
+        // when
+        vm.recordLogs();
+        vm.prank(owner);
+        pauser.removeFromWhitelist(address(vault), guardian);
+
+        // then
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 0, "no event should be emitted on redundant remove");
+        assertFalse(pauser.isWhitelisted(address(vault), guardian), "account should not be whitelisted");
+    }
+
+    function testShouldWhitelistBeScopedPerVault() public {
+        // when
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        assertTrue(pauser.isWhitelisted(address(vault), guardian), "account should be whitelisted for vault");
+        assertFalse(pauser.isWhitelisted(address(vaultB), guardian), "account should not be whitelisted for vaultB");
+    }
+
+    //
+    // Whitelist enumeration
+    //
+
+    function testShouldListWhitelistedAccountsForVault() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vault), user);
+        pauser.addToWhitelist(address(vaultB), guardian);
+        vm.stopPrank();
+
+        // when
+        address[] memory vaultAccounts = pauser.getWhitelistedAccounts(address(vault));
+        address[] memory vaultBAccounts = pauser.getWhitelistedAccounts(address(vaultB));
+
+        // then
+        assertEq(vaultAccounts.length, 2, "vault should have two whitelisted accounts");
+        assertEq(vaultAccounts[0], guardian, "first whitelisted account should be listed");
+        assertEq(vaultAccounts[1], user, "second whitelisted account should be listed");
+        assertEq(vaultBAccounts.length, 1, "vaultB should have one whitelisted account");
+        assertEq(vaultBAccounts[0], guardian, "vaultB whitelisted account should be listed");
+    }
+
+    function testShouldListWhitelistedVaultsForAccount() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vaultB), guardian);
+        vm.stopPrank();
+
+        // when
+        address[] memory guardianVaults = pauser.getWhitelistedVaults(guardian);
+
+        // then
+        assertEq(guardianVaults.length, 2, "guardian should have two vaults");
+        assertEq(guardianVaults[0], address(vault), "first vault should be listed");
+        assertEq(guardianVaults[1], address(vaultB), "second vault should be listed");
+        assertEq(pauser.getWhitelistedVaults(user).length, 0, "user should have no vaults");
+    }
+
+    function testShouldKeepBothWhitelistSidesInSyncAfterRemoval() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vault), user);
+        pauser.addToWhitelist(address(vaultB), guardian);
+
+        // when
+        pauser.removeFromWhitelist(address(vault), guardian);
+        vm.stopPrank();
+
+        // then
+        address[] memory vaultAccounts = pauser.getWhitelistedAccounts(address(vault));
+        assertEq(vaultAccounts.length, 1, "vault should have one whitelisted account left");
+        assertEq(vaultAccounts[0], user, "remaining whitelisted account should be listed");
+
+        address[] memory guardianVaults = pauser.getWhitelistedVaults(guardian);
+        assertEq(guardianVaults.length, 1, "guardian should have one vault left");
+        assertEq(guardianVaults[0], address(vaultB), "remaining vault should be listed");
+    }
+
+    function testShouldReturnEmptyListsWhenNothingWhitelisted() public {
+        // then
+        assertEq(pauser.getWhitelistedAccounts(address(vault)).length, 0, "accounts list should be empty");
+        assertEq(pauser.getWhitelistedVaults(guardian).length, 0, "vaults list should be empty");
+    }
+
+    function testShouldReturnWhitelistCounts() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vault), user);
+        pauser.addToWhitelist(address(vaultB), guardian);
+        vm.stopPrank();
+
+        // then
+        assertEq(pauser.getWhitelistedAccountsCount(address(vault)), 2, "vault should have two whitelisted accounts");
+        assertEq(pauser.getWhitelistedAccountsCount(address(vaultB)), 1, "vaultB should have one whitelisted account");
+        assertEq(pauser.getWhitelistedVaultsCount(guardian), 2, "guardian should have two vaults");
+        assertEq(pauser.getWhitelistedVaultsCount(user), 1, "user should have one vault");
+        assertEq(pauser.getWhitelistedAccountsCount(makeAddr("unknownVault")), 0, "unknown vault should be empty");
+        assertEq(pauser.getWhitelistedVaultsCount(makeAddr("unknownAccount")), 0, "unknown account should be empty");
+    }
+
+    function testShouldPaginateWhitelistedAccounts() public {
+        // given - five accounts whitelisted for the vault
+        address[] memory accounts = new address[](5);
+        vm.startPrank(owner);
+        for (uint256 i; i < accounts.length; ++i) {
+            accounts[i] = makeAddr(string.concat("account", vm.toString(i)));
+            pauser.addToWhitelist(address(vault), accounts[i]);
+        }
+        vm.stopPrank();
+
+        // when - reading in pages of two
+        address[] memory pageOne = pauser.getWhitelistedAccounts(address(vault), 0, 2);
+        address[] memory pageTwo = pauser.getWhitelistedAccounts(address(vault), 2, 2);
+        address[] memory pageThree = pauser.getWhitelistedAccounts(address(vault), 4, 2);
+
+        // then - pages concatenate to the full list
+        address[] memory all = pauser.getWhitelistedAccounts(address(vault));
+        assertEq(all.length, 5, "full list should have five entries");
+        assertEq(pageOne.length, 2, "first page should have two entries");
+        assertEq(pageTwo.length, 2, "second page should have two entries");
+        assertEq(pageThree.length, 1, "last page should be truncated to the remaining entry");
+        assertEq(pageOne[0], all[0], "page element should match the full list");
+        assertEq(pageOne[1], all[1], "page element should match the full list");
+        assertEq(pageTwo[0], all[2], "page element should match the full list");
+        assertEq(pageTwo[1], all[3], "page element should match the full list");
+        assertEq(pageThree[0], all[4], "page element should match the full list");
+    }
+
+    function testShouldPaginateWhitelistedVaults() public {
+        // given - guardian whitelisted for three vaults
+        address[] memory vaults = new address[](3);
+        vm.startPrank(owner);
+        for (uint256 i; i < vaults.length; ++i) {
+            vaults[i] = makeAddr(string.concat("vault", vm.toString(i)));
+            pauser.addToWhitelist(vaults[i], guardian);
+        }
+        vm.stopPrank();
+
+        // when
+        address[] memory pageOne = pauser.getWhitelistedVaults(guardian, 0, 2);
+        address[] memory pageTwo = pauser.getWhitelistedVaults(guardian, 2, 2);
+
+        // then
+        address[] memory all = pauser.getWhitelistedVaults(guardian);
+        assertEq(all.length, 3, "full list should have three entries");
+        assertEq(pageOne.length, 2, "first page should have two entries");
+        assertEq(pageTwo.length, 1, "second page should be truncated to the remaining entry");
+        assertEq(pageOne[0], all[0], "page element should match the full list");
+        assertEq(pageOne[1], all[1], "page element should match the full list");
+        assertEq(pageTwo[0], all[2], "page element should match the full list");
+    }
+
+    function testShouldReturnEmptyPageWhenOffsetOutOfRange() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        assertEq(pauser.getWhitelistedAccounts(address(vault), 1, 10).length, 0, "offset equal to length");
+        assertEq(pauser.getWhitelistedAccounts(address(vault), 100, 10).length, 0, "offset above length");
+        assertEq(pauser.getWhitelistedVaults(guardian, 1, 10).length, 0, "offset equal to length");
+        assertEq(pauser.getWhitelistedVaults(guardian, 100, 10).length, 0, "offset above length");
+    }
+
+    function testShouldReturnEmptyPageWhenLimitIsZero() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // then
+        assertEq(pauser.getWhitelistedAccounts(address(vault), 0, 0).length, 0, "zero limit should return empty page");
+        assertEq(pauser.getWhitelistedVaults(guardian, 0, 0).length, 0, "zero limit should return empty page");
+    }
+
+    function testShouldListAllConfiguredVaultsAndAccounts() public {
+        // given - empty at start
+        assertEq(pauser.getVaultsCount(), 0, "no vaults should be configured initially");
+        assertEq(pauser.getAccountsCount(), 0, "no accounts should be configured initially");
+
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vault), user);
+        pauser.addToWhitelist(address(vaultB), guardian);
+        vm.stopPrank();
+
+        // when
+        address[] memory allVaults = pauser.getVaults();
+        address[] memory allAccounts = pauser.getAccounts();
+
+        // then - every configured vault and account listed exactly once
+        assertEq(allVaults.length, 2, "two vaults should be configured");
+        assertEq(allVaults[0], address(vault), "vault should be listed");
+        assertEq(allVaults[1], address(vaultB), "vaultB should be listed");
+        assertEq(allAccounts.length, 2, "two accounts should be configured");
+        assertEq(allAccounts[0], guardian, "guardian should be listed once despite two vaults");
+        assertEq(allAccounts[1], user, "user should be listed");
+        assertEq(pauser.getVaultsCount(), 2, "vaults count should match the list");
+        assertEq(pauser.getAccountsCount(), 2, "accounts count should match the list");
+    }
+
+    function testShouldRemoveVaultFromGlobalListWhenLastAccountRemoved() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vault), user);
+
+        // when - one account removed, the vault stays configured
+        pauser.removeFromWhitelist(address(vault), guardian);
+        assertEq(pauser.getVaultsCount(), 1, "vault should stay configured while one account is left");
+
+        // and - the last account removed
+        pauser.removeFromWhitelist(address(vault), user);
+        vm.stopPrank();
+
+        // then
+        assertEq(pauser.getVaultsCount(), 0, "vault should be removed together with its last account");
+        assertEq(pauser.getVaults().length, 0, "vaults list should be empty");
+        assertEq(pauser.getAccountsCount(), 0, "accounts list should be empty as well");
+    }
+
+    function testShouldRemoveAccountFromGlobalListWhenLastVaultRemoved() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.addToWhitelist(address(vaultB), guardian);
+
+        // when - guardian removed from one vault, still configured for the other
+        pauser.removeFromWhitelist(address(vault), guardian);
+        assertEq(pauser.getAccountsCount(), 1, "account should stay configured while one vault is left");
+
+        // and - removed from the last vault
+        pauser.removeFromWhitelist(address(vaultB), guardian);
+        vm.stopPrank();
+
+        // then
+        assertEq(pauser.getAccountsCount(), 0, "account should be removed together with its last vault");
+        assertEq(pauser.getAccounts().length, 0, "accounts list should be empty");
+        assertEq(pauser.getVaultsCount(), 0, "vaults list should be empty as well");
+    }
+
+    function testShouldPaginateGlobalVaultsAndAccountsLists() public {
+        // given - three vaults each with a distinct account
+        vm.startPrank(owner);
+        for (uint256 i; i < 3; ++i) {
+            pauser.addToWhitelist(
+                makeAddr(string.concat("vault", vm.toString(i))),
+                makeAddr(string.concat("account", vm.toString(i)))
+            );
+        }
+        vm.stopPrank();
+
+        // when
+        address[] memory vaultsPageOne = pauser.getVaults(0, 2);
+        address[] memory vaultsPageTwo = pauser.getVaults(2, 2);
+        address[] memory accountsPageOne = pauser.getAccounts(0, 2);
+        address[] memory accountsPageTwo = pauser.getAccounts(2, 2);
+
+        // then
+        address[] memory allVaults = pauser.getVaults();
+        address[] memory allAccounts = pauser.getAccounts();
+        assertEq(vaultsPageOne.length, 2, "first vaults page should have two entries");
+        assertEq(vaultsPageTwo.length, 1, "second vaults page should be truncated");
+        assertEq(vaultsPageOne[0], allVaults[0], "page element should match the full list");
+        assertEq(vaultsPageOne[1], allVaults[1], "page element should match the full list");
+        assertEq(vaultsPageTwo[0], allVaults[2], "page element should match the full list");
+        assertEq(accountsPageOne.length, 2, "first accounts page should have two entries");
+        assertEq(accountsPageTwo.length, 1, "second accounts page should be truncated");
+        assertEq(accountsPageOne[0], allAccounts[0], "page element should match the full list");
+        assertEq(accountsPageOne[1], allAccounts[1], "page element should match the full list");
+        assertEq(accountsPageTwo[0], allAccounts[2], "page element should match the full list");
+    }
+
+    function testFuzzShouldPaginateConsistentlyWithFullList(uint256 count_, uint256 offset_, uint256 limit_) public {
+        // given
+        count_ = bound(count_, 0, 8);
+        offset_ = bound(offset_, 0, 10);
+        limit_ = bound(limit_, 0, 10);
+
+        vm.startPrank(owner);
+        for (uint256 i; i < count_; ++i) {
+            pauser.addToWhitelist(address(vault), makeAddr(string.concat("account", vm.toString(i))));
+        }
+        vm.stopPrank();
+
+        // when
+        address[] memory page = pauser.getWhitelistedAccounts(address(vault), offset_, limit_);
+        address[] memory all = pauser.getWhitelistedAccounts(address(vault));
+
+        // then
+        uint256 remaining = offset_ >= count_ ? 0 : count_ - offset_;
+        uint256 expectedSize = remaining < limit_ ? remaining : limit_;
+        assertEq(page.length, expectedSize, "page size should match expected");
+        for (uint256 i; i < page.length; ++i) {
+            assertEq(page[i], all[offset_ + i], "page element should match the full list");
+        }
+    }
+
+    //
+    // Pause
+    //
+
+    function testShouldPauseVaultWhenWhitelisted() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit PlasmaVaultPauser.VaultPaused(address(vault), address(accessManager), guardian);
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+
+        // then
+        assertEq(accessManager.lastTarget(), address(vault), "updateTargetClosed should be called with the vault");
+        assertTrue(accessManager.lastClosed(), "updateTargetClosed should be called with closed = true");
+        assertEq(accessManager.updateTargetClosedCallCount(), 1, "updateTargetClosed should be called once");
+        assertTrue(accessManager.isTargetClosed(address(vault)), "vault should be closed");
+    }
+
+    function testShouldPauseAgainWhenAlreadyPaused() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+
+        // when
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+
+        // then
+        assertEq(accessManager.updateTargetClosedCallCount(), 2, "updateTargetClosed should be called twice");
+        assertTrue(accessManager.isTargetClosed(address(vault)), "vault should stay closed");
+    }
+
+    function testShouldNotPauseWhenNotWhitelisted() public {
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(PlasmaVaultPauser.AccountNotWhitelisted.selector, address(vault), user));
+        vm.prank(user);
+        pauser.pause(address(vault));
+
+        assertEq(accessManager.updateTargetClosedCallCount(), 0, "updateTargetClosed should not be called");
+    }
+
+    function testShouldNotPauseWhenOwnerNotWhitelisted() public {
+        // when / then - the owner has no implicit right to pause
+        vm.expectRevert(
+            abi.encodeWithSelector(PlasmaVaultPauser.AccountNotWhitelisted.selector, address(vault), owner)
+        );
+        vm.prank(owner);
+        pauser.pause(address(vault));
+    }
+
+    function testShouldNotPauseOtherVaultThanWhitelistedFor() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when / then
+        vm.expectRevert(
+            abi.encodeWithSelector(PlasmaVaultPauser.AccountNotWhitelisted.selector, address(vaultB), guardian)
+        );
+        vm.prank(guardian);
+        pauser.pause(address(vaultB));
+
+        assertEq(accessManager.updateTargetClosedCallCount(), 0, "updateTargetClosed should not be called");
+    }
+
+    function testShouldNotPauseAfterRemovalFromWhitelist() public {
+        // given
+        vm.startPrank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        pauser.removeFromWhitelist(address(vault), guardian);
+        vm.stopPrank();
+
+        // when / then
+        vm.expectRevert(
+            abi.encodeWithSelector(PlasmaVaultPauser.AccountNotWhitelisted.selector, address(vault), guardian)
+        );
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+    }
+
+    function testShouldNotPauseWhenAuthorityIsZeroAddress() public {
+        // given
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+        vault.setAuthority(address(0));
+
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(PlasmaVaultPauser.InvalidAuthority.selector, address(vault)));
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+    }
+
+    function testShouldNotPauseWhenAccessManagerDoesNotCloseVault() public {
+        // given
+        MockSilentAccessManager silentAccessManager = new MockSilentAccessManager();
+        vault.setAuthority(address(silentAccessManager));
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when / then
+        vm.expectRevert(abi.encodeWithSelector(PlasmaVaultPauser.VaultPauseFailed.selector, address(vault)));
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+    }
+
+    function testShouldNotPauseWhenVaultIsNotAContract() public {
+        // given
+        address eoaVault = makeAddr("eoaVault");
+        vm.prank(owner);
+        pauser.addToWhitelist(eoaVault, guardian);
+
+        // when / then
+        vm.expectRevert();
+        vm.prank(guardian);
+        pauser.pause(eoaVault);
+    }
+
+    //
+    // Fuzz
+    //
+
+    function testFuzzShouldNotPauseWhenCallerNotWhitelisted(address caller_) public {
+        // given
+        vm.assume(caller_ != guardian);
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+
+        // when / then
+        vm.expectRevert(
+            abi.encodeWithSelector(PlasmaVaultPauser.AccountNotWhitelisted.selector, address(vault), caller_)
+        );
+        vm.prank(caller_);
+        pauser.pause(address(vault));
+    }
+
+    function testFuzzShouldManageWhitelistForAnyVaultAndAccount(address vault_, address account_) public {
+        // given
+        vm.assume(vault_ != address(0));
+        vm.assume(account_ != address(0));
+
+        // when / then
+        vm.startPrank(owner);
+        pauser.addToWhitelist(vault_, account_);
+        assertTrue(pauser.isWhitelisted(vault_, account_), "account should be whitelisted");
+        assertEq(pauser.getWhitelistedAccounts(vault_).length, 1, "accounts list should have one entry");
+        assertEq(pauser.getWhitelistedVaults(account_).length, 1, "vaults list should have one entry");
+        assertEq(pauser.getVaultsCount(), 1, "global vaults list should have one entry");
+        assertEq(pauser.getAccountsCount(), 1, "global accounts list should have one entry");
+
+        pauser.removeFromWhitelist(vault_, account_);
+        assertFalse(pauser.isWhitelisted(vault_, account_), "account should not be whitelisted");
+        assertEq(pauser.getWhitelistedAccounts(vault_).length, 0, "accounts list should be empty");
+        assertEq(pauser.getWhitelistedVaults(account_).length, 0, "vaults list should be empty");
+        assertEq(pauser.getVaultsCount(), 0, "global vaults list should be empty");
+        assertEq(pauser.getAccountsCount(), 0, "global accounts list should be empty");
+        vm.stopPrank();
+    }
+}
+
+contract PlasmaVaultPauserIntegrationTest is Test {
+    PlasmaVaultPauser internal pauser;
+    IporFusionAccessManager internal accessManager;
+    MockAccessManagedVault internal vault;
+
+    address internal admin;
+    address internal owner;
+    address internal guardian;
+    address internal user;
+
+    bytes4 internal constant DEPOSIT_SELECTOR = bytes4(keccak256("deposit(uint256,address)"));
+
+    function setUp() public {
+        admin = makeAddr("admin");
+        owner = makeAddr("owner");
+        guardian = makeAddr("guardian");
+        user = makeAddr("user");
+
+        accessManager = new IporFusionAccessManager(admin, 0);
+        vault = new MockAccessManagedVault(address(accessManager));
+
+        pauser = new PlasmaVaultPauser(owner);
+
+        bytes4[] memory updateTargetClosedSelectors = new bytes4[](1);
+        updateTargetClosedSelectors[0] = IIporFusionAccessManager.updateTargetClosed.selector;
+
+        bytes4[] memory depositSelectors = new bytes4[](1);
+        depositSelectors[0] = DEPOSIT_SELECTOR;
+
+        vm.startPrank(admin);
+        accessManager.setTargetFunctionRole(address(accessManager), updateTargetClosedSelectors, Roles.GUARDIAN_ROLE);
+        accessManager.grantRole(Roles.GUARDIAN_ROLE, address(pauser), 0);
+        /// @dev simulate a public vault function to observe the effect of closing the target
+        accessManager.setTargetFunctionRole(address(vault), depositSelectors, Roles.PUBLIC_ROLE);
+        vm.stopPrank();
+
+        vm.prank(owner);
+        pauser.addToWhitelist(address(vault), guardian);
+    }
+
+    function testShouldPauseVaultOnRealAccessManager() public {
+        // given
+        assertFalse(accessManager.isTargetClosed(address(vault)), "vault should be open before pause");
+        (bool immediateBefore, ) = accessManager.canCall(user, address(vault), DEPOSIT_SELECTOR);
+        assertTrue(immediateBefore, "public vault function should be callable before pause");
+
+        // when
+        vm.expectEmit(true, true, true, true);
+        emit PlasmaVaultPauser.VaultPaused(address(vault), address(accessManager), guardian);
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+
+        // then
+        assertTrue(accessManager.isTargetClosed(address(vault)), "vault should be closed after pause");
+        (bool immediateAfter, uint32 delayAfter) = accessManager.canCall(user, address(vault), DEPOSIT_SELECTOR);
+        assertFalse(immediateAfter, "vault functions should be blocked after pause");
+        assertEq(delayAfter, 0, "no delayed execution should be possible on a closed target");
+    }
+
+    function testShouldPauseBeIdempotentOnRealAccessManager() public {
+        // when
+        vm.startPrank(guardian);
+        pauser.pause(address(vault));
+        pauser.pause(address(vault));
+        vm.stopPrank();
+
+        // then
+        assertTrue(accessManager.isTargetClosed(address(vault)), "vault should stay closed");
+    }
+
+    function testShouldNotPauseWhenPauserContractHasNoGuardianRole() public {
+        // given - a pauser which was never granted GUARDIAN_ROLE on the access manager
+        vm.startPrank(owner);
+        PlasmaVaultPauser pauserWithoutRole = new PlasmaVaultPauser(owner);
+        pauserWithoutRole.addToWhitelist(address(vault), guardian);
+        vm.stopPrank();
+
+        // when / then
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IporFusionAccessManager.AccessManagedUnauthorized.selector,
+                address(pauserWithoutRole)
+            )
+        );
+        vm.prank(guardian);
+        pauserWithoutRole.pause(address(vault));
+
+        assertFalse(accessManager.isTargetClosed(address(vault)), "vault should stay open");
+    }
+
+    function testShouldNotWhitelistedAccountCallAccessManagerDirectly() public {
+        // when / then - the whitelisted account has no GUARDIAN_ROLE, only the pauser contract has it
+        vm.expectRevert(abi.encodeWithSelector(IporFusionAccessManager.AccessManagedUnauthorized.selector, guardian));
+        vm.prank(guardian);
+        accessManager.updateTargetClosed(address(vault), true);
+    }
+
+    function testShouldGuardianReopenVaultPausedByPauser() public {
+        // given
+        vm.prank(guardian);
+        pauser.pause(address(vault));
+        assertTrue(accessManager.isTargetClosed(address(vault)), "vault should be closed after pause");
+
+        address humanGuardian = makeAddr("humanGuardian");
+        vm.prank(admin);
+        accessManager.grantRole(Roles.GUARDIAN_ROLE, humanGuardian, 0);
+
+        // when - reopening happens directly on the access manager, the pauser cannot do it
+        vm.prank(humanGuardian);
+        accessManager.updateTargetClosed(address(vault), false);
+
+        // then
+        assertFalse(accessManager.isTargetClosed(address(vault)), "vault should be reopened by the guardian");
+    }
+}

--- a/test/managers/RedemptionDelayTimelockTest.t.sol
+++ b/test/managers/RedemptionDelayTimelockTest.t.sol
@@ -1,0 +1,510 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {FusionFactory} from "../../contracts/factory/FusionFactory.sol";
+import {FusionFactoryLogicLib} from "../../contracts/factory/lib/FusionFactoryLogicLib.sol";
+import {RewardsManagerFactory} from "../../contracts/factory/RewardsManagerFactory.sol";
+import {WithdrawManagerFactory} from "../../contracts/factory/WithdrawManagerFactory.sol";
+import {ContextManagerFactory} from "../../contracts/factory/ContextManagerFactory.sol";
+import {PriceManagerFactory} from "../../contracts/factory/PriceManagerFactory.sol";
+import {PlasmaVaultFactory} from "../../contracts/factory/PlasmaVaultFactory.sol";
+import {AccessManagerFactory} from "../../contracts/factory/AccessManagerFactory.sol";
+import {FeeManagerFactory} from "../../contracts/managers/fee/FeeManagerFactory.sol";
+import {MockERC20} from "../test_helpers/MockERC20.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IporFusionMarkets} from "../../contracts/libraries/IporFusionMarkets.sol";
+import {BurnRequestFeeFuse} from "../../contracts/fuses/burn_request_fee/BurnRequestFeeFuse.sol";
+import {ZeroBalanceFuse} from "../../contracts/fuses/ZeroBalanceFuse.sol";
+import {PlasmaVaultBase} from "../../contracts/vaults/PlasmaVaultBase.sol";
+import {PriceOracleMiddleware} from "../../contracts/price_oracle/PriceOracleMiddleware.sol";
+import {IporFusionAccessManager} from "../../contracts/managers/access/IporFusionAccessManager.sol";
+import {WithdrawManager} from "../../contracts/managers/withdraw/WithdrawManager.sol";
+import {RewardsClaimManager} from "../../contracts/managers/rewards/RewardsClaimManager.sol";
+import {PlasmaVault, PlasmaVaultInitData} from "../../contracts/vaults/PlasmaVault.sol";
+import {FusionFactoryStorageLib} from "../../contracts/factory/lib/FusionFactoryStorageLib.sol";
+import {IPlasmaVaultGovernance} from "../../contracts/interfaces/IPlasmaVaultGovernance.sol";
+import {Roles} from "../../contracts/libraries/Roles.sol";
+import {ContextManager} from "../../contracts/managers/context/ContextManager.sol";
+import {PriceOracleMiddlewareManager} from "../../contracts/managers/price/PriceOracleMiddlewareManager.sol";
+import {FeeConfig} from "../../contracts/managers/fee/FeeManagerFactory.sol";
+
+/// @title RedemptionDelayTimelockTest
+/// @notice Proves that the IL-7910 redemption delay setter can be put behind the OWNER_ROLE timelock.
+/// @dev Uses a vault created by FusionFactory (local, no fork) so the role wiring produced by
+/// IporFusionAccessManagerInitializerLibV1 is exercised end-to-end:
+///      - PlasmaVaultGovernance.setRedemptionDelay is the OWNER_ROLE entry point on the vault target,
+///      - IporFusionAccessManager.setRedemptionDelay is reserved for the vault (TECH_PLASMA_VAULT_ROLE).
+///      An owner granted with an execution delay must schedule the change, wait, then execute - and a
+///      guardian may cancel it - exactly like every other governance function. The entry point cannot
+///      live on the access manager itself: OpenZeppelin AccessManager refuses to schedule/execute its own
+///      custom functions (only the built-in admin selectors are recognised when the target is the manager),
+///      so a setter restricted there to the OWNER_ROLE would be immediate for owners without a delay and
+///      unusable for owners with one.
+contract RedemptionDelayTimelockTest is Test {
+    uint256 private constant TIMELOCK_24H = 24 hours;
+    uint256 private constant INITIAL_REDEMPTION_DELAY = 1 days;
+    uint256 private constant NEW_REDEMPTION_DELAY = 3 days;
+    uint256 private constant DEPOSIT_AMOUNT = 1000 * 1e18;
+
+    FusionFactory private fusionFactory;
+    FusionFactoryStorageLib.FactoryAddresses private factoryAddresses;
+    MockERC20 private underlyingToken;
+
+    address private plasmaVaultBase;
+    address private priceOracleMiddleware;
+    address private burnRequestFeeFuse;
+    address private burnRequestFeeBalanceFuse;
+
+    address private owner;
+    address private timelockedOwner;
+    address private guardian;
+    address private atomist;
+    address private depositor;
+    address private daoFeeRecipient;
+    address private daoFeeManager;
+    address private maintenanceManager;
+
+    IporFusionAccessManager private accessManager;
+    PlasmaVault private plasmaVault;
+
+    event RedemptionDelayUpdated(uint256 newRedemptionDelayInSeconds);
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        timelockedOwner = makeAddr("timelockedOwner");
+        guardian = makeAddr("guardian");
+        atomist = makeAddr("atomist");
+        depositor = makeAddr("depositor");
+        daoFeeRecipient = makeAddr("daoFeeRecipient");
+        daoFeeManager = makeAddr("daoFeeManager");
+        maintenanceManager = makeAddr("maintenanceManager");
+
+        underlyingToken = new MockERC20("Test Token", "TEST", 18);
+
+        factoryAddresses = FusionFactoryStorageLib.FactoryAddresses({
+            accessManagerFactory: address(new AccessManagerFactory()),
+            plasmaVaultFactory: address(new PlasmaVaultFactory()),
+            feeManagerFactory: address(new FeeManagerFactory()),
+            withdrawManagerFactory: address(new WithdrawManagerFactory()),
+            rewardsManagerFactory: address(new RewardsManagerFactory()),
+            contextManagerFactory: address(new ContextManagerFactory()),
+            priceManagerFactory: address(new PriceManagerFactory())
+        });
+
+        plasmaVaultBase = address(new PlasmaVaultBase());
+        burnRequestFeeFuse = address(new BurnRequestFeeFuse(IporFusionMarkets.ZERO_BALANCE_MARKET));
+        burnRequestFeeBalanceFuse = address(new ZeroBalanceFuse(IporFusionMarkets.ZERO_BALANCE_MARKET));
+
+        PriceOracleMiddleware implementation = new PriceOracleMiddleware(address(0));
+        priceOracleMiddleware = address(
+            new ERC1967Proxy(address(implementation), abi.encodeWithSignature("initialize(address)", owner))
+        );
+
+        FusionFactory fusionFactoryImplementation = new FusionFactory();
+        bytes memory initData = abi.encodeWithSignature(
+            "initialize(address,(address,address,address,address,address,address,address),address,address,address,address)",
+            owner,
+            factoryAddresses,
+            plasmaVaultBase,
+            priceOracleMiddleware,
+            burnRequestFeeFuse,
+            burnRequestFeeBalanceFuse
+        );
+        fusionFactory = FusionFactory(address(new ERC1967Proxy(address(fusionFactoryImplementation), initData)));
+
+        vm.startPrank(owner);
+        fusionFactory.grantRole(fusionFactory.DAO_FEE_MANAGER_ROLE(), daoFeeManager);
+        fusionFactory.grantRole(fusionFactory.MAINTENANCE_MANAGER_ROLE(), maintenanceManager);
+        vm.stopPrank();
+
+        vm.startPrank(daoFeeManager);
+        FusionFactoryStorageLib.FeePackage[] memory packages = new FusionFactoryStorageLib.FeePackage[](1);
+        packages[0] = FusionFactoryStorageLib.FeePackage({
+            managementFee: 333,
+            performanceFee: 777,
+            feeRecipient: daoFeeRecipient
+        });
+        fusionFactory.setDaoFeePackages(packages);
+        vm.stopPrank();
+
+        address[] memory approvedAddresses = new address[](1);
+        approvedAddresses[0] = address(1);
+
+        address accessManagerBase = address(new IporFusionAccessManager(owner, 1 seconds));
+        address withdrawManagerBase = address(new WithdrawManager(accessManagerBase));
+        address contextManagerBase = address(new ContextManager(owner, approvedAddresses));
+        address priceManagerBase = address(new PriceOracleMiddlewareManager(owner, priceOracleMiddleware));
+
+        address plasmaVaultCoreBase = address(new PlasmaVault());
+        PlasmaVault(plasmaVaultCoreBase).proxyInitialize(
+            PlasmaVaultInitData({
+                assetName: "fake",
+                assetSymbol: "fake",
+                underlyingToken: address(underlyingToken),
+                priceOracleMiddleware: priceOracleMiddleware,
+                feeConfig: FeeConfig({
+                    feeFactory: factoryAddresses.feeManagerFactory,
+                    iporDaoManagementFee: 111,
+                    iporDaoPerformanceFee: 222,
+                    iporDaoFeeRecipientAddress: address(this)
+                }),
+                accessManager: accessManagerBase,
+                plasmaVaultBase: plasmaVaultBase,
+                withdrawManager: withdrawManagerBase,
+                plasmaVaultVotesPlugin: address(0)
+            })
+        );
+
+        address rewardsManagerBase = address(new RewardsClaimManager(owner, plasmaVaultCoreBase));
+
+        vm.startPrank(maintenanceManager);
+        fusionFactory.updateBaseAddresses(
+            1,
+            plasmaVaultCoreBase,
+            accessManagerBase,
+            priceManagerBase,
+            withdrawManagerBase,
+            rewardsManagerBase,
+            contextManagerBase
+        );
+        vm.stopPrank();
+
+        FusionFactoryLogicLib.FusionInstance memory instance = fusionFactory.clone(
+            "Test Vault",
+            "TVAULT",
+            address(underlyingToken),
+            INITIAL_REDEMPTION_DELAY,
+            owner,
+            0
+        );
+
+        accessManager = IporFusionAccessManager(instance.accessManager);
+        plasmaVault = PlasmaVault(payable(instance.plasmaVault));
+    }
+
+    function testShouldFactoryWireRedemptionDelaySetterForTimelock() public view {
+        // then - the owner-facing entry point is on the vault target, the access manager one is vault-only
+        assertEq(
+            accessManager.getTargetFunctionRole(
+                address(plasmaVault),
+                IPlasmaVaultGovernance.setRedemptionDelay.selector
+            ),
+            Roles.OWNER_ROLE,
+            "PlasmaVaultGovernance.setRedemptionDelay should be OWNER_ROLE restricted"
+        );
+        assertEq(
+            accessManager.getTargetFunctionRole(
+                address(accessManager),
+                IporFusionAccessManager.setRedemptionDelay.selector
+            ),
+            Roles.TECH_PLASMA_VAULT_ROLE,
+            "IporFusionAccessManager.setRedemptionDelay should be TECH_PLASMA_VAULT_ROLE restricted"
+        );
+        assertEq(
+            accessManager.getRoleGuardian(Roles.OWNER_ROLE),
+            Roles.GUARDIAN_ROLE,
+            "GUARDIAN_ROLE should be able to cancel scheduled OWNER_ROLE operations"
+        );
+    }
+
+    function testShouldOwnerWithoutExecutionDelaySetRedemptionDelayImmediatelyThroughVault() public {
+        // given
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY);
+
+        // when
+        vm.expectEmit(address(accessManager));
+        emit RedemptionDelayUpdated(NEW_REDEMPTION_DELAY);
+        vm.prank(owner);
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(NEW_REDEMPTION_DELAY);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), NEW_REDEMPTION_DELAY);
+    }
+
+    function testShouldRequireScheduleAndWaitForOwnerWithExecutionDelay() public {
+        // given
+        _setupTimelockedOwner();
+
+        bytes memory data = _setRedemptionDelayCalldata(NEW_REDEMPTION_DELAY);
+        bytes32 operationId = accessManager.hashOperation(timelockedOwner, address(plasmaVault), data);
+
+        // when/then - a direct call by the timelocked owner is refused until the operation is scheduled
+        vm.expectRevert(abi.encodeWithSignature("AccessManagerNotScheduled(bytes32)", operationId));
+        vm.prank(timelockedOwner);
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(NEW_REDEMPTION_DELAY);
+
+        // when - the owner schedules the change on the vault target
+        uint48 executeAt = uint48(block.timestamp + TIMELOCK_24H);
+        vm.prank(timelockedOwner);
+        (bytes32 scheduledOperationId, ) = accessManager.schedule(address(plasmaVault), data, executeAt);
+
+        // then
+        assertEq(scheduledOperationId, operationId, "scheduled operation id");
+        assertEq(accessManager.getSchedule(operationId), executeAt, "operation should be scheduled");
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY, "unchanged until executed");
+
+        // when/then - execution before the delay elapses is refused
+        vm.expectRevert(abi.encodeWithSignature("AccessManagerNotReady(bytes32)", operationId));
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(plasmaVault), data);
+
+        vm.warp(executeAt - 1);
+        vm.expectRevert(abi.encodeWithSignature("AccessManagerNotReady(bytes32)", operationId));
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(plasmaVault), data);
+
+        // when - the delay elapsed, the owner executes the scheduled change
+        vm.warp(executeAt);
+        vm.expectEmit(address(accessManager));
+        emit RedemptionDelayUpdated(NEW_REDEMPTION_DELAY);
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(plasmaVault), data);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), NEW_REDEMPTION_DELAY);
+        assertEq(accessManager.getSchedule(operationId), 0, "schedule should be consumed");
+
+        // and - the consumed schedule cannot be replayed
+        vm.expectRevert(abi.encodeWithSignature("AccessManagerNotScheduled(bytes32)", operationId));
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(plasmaVault), data);
+    }
+
+    function testShouldConsumeScheduledRedemptionDelayChangeByDirectCallAfterDelay() public {
+        // given
+        _setupTimelockedOwner();
+
+        bytes memory data = _setRedemptionDelayCalldata(NEW_REDEMPTION_DELAY);
+        bytes32 operationId = accessManager.hashOperation(timelockedOwner, address(plasmaVault), data);
+
+        vm.prank(timelockedOwner);
+        accessManager.schedule(address(plasmaVault), data, uint48(block.timestamp + TIMELOCK_24H));
+
+        vm.warp(block.timestamp + TIMELOCK_24H);
+
+        // when - calling the vault directly consumes the scheduled operation (AccessManaged flow)
+        vm.prank(timelockedOwner);
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(NEW_REDEMPTION_DELAY);
+
+        // then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), NEW_REDEMPTION_DELAY);
+        assertEq(accessManager.getSchedule(operationId), 0, "schedule should be consumed");
+    }
+
+    function testShouldGuardianCancelScheduledRedemptionDelayChange() public {
+        // given
+        _setupTimelockedOwner();
+
+        bytes memory data = _setRedemptionDelayCalldata(0);
+        bytes32 operationId = accessManager.hashOperation(timelockedOwner, address(plasmaVault), data);
+
+        vm.prank(timelockedOwner);
+        (, uint32 scheduleNonce) = accessManager.schedule(
+            address(plasmaVault),
+            data,
+            uint48(block.timestamp + TIMELOCK_24H)
+        );
+
+        // when
+        vm.prank(guardian);
+        uint32 cancelNonce = accessManager.cancel(timelockedOwner, address(plasmaVault), data);
+
+        // then
+        assertEq(cancelNonce, scheduleNonce, "cancel nonce should match schedule nonce");
+        assertEq(accessManager.getSchedule(operationId), 0, "operation should be cancelled");
+
+        vm.warp(block.timestamp + TIMELOCK_24H + 1);
+
+        vm.expectRevert(abi.encodeWithSignature("AccessManagerNotScheduled(bytes32)", operationId));
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(plasmaVault), data);
+
+        vm.expectRevert(abi.encodeWithSignature("AccessManagerNotScheduled(bytes32)", operationId));
+        vm.prank(timelockedOwner);
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(0);
+
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY, "delay should be unchanged");
+    }
+
+    function testShouldNotScheduleRedemptionDelayChangeEarlierThanExecutionDelay() public {
+        // given
+        _setupTimelockedOwner();
+
+        bytes memory data = _setRedemptionDelayCalldata(NEW_REDEMPTION_DELAY);
+
+        // when/then
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "AccessManagerUnauthorizedCall(address,address,bytes4)",
+                timelockedOwner,
+                address(plasmaVault),
+                IPlasmaVaultGovernance.setRedemptionDelay.selector
+            )
+        );
+        vm.prank(timelockedOwner);
+        accessManager.schedule(address(plasmaVault), data, uint48(block.timestamp + TIMELOCK_24H - 1));
+    }
+
+    function testShouldNotGrantOwnerRoleBelowMinimalExecutionDelay() public {
+        // given - the minimal execution delay makes every future owner timelocked
+        _setupTimelockedOwner();
+        address anotherOwner = makeAddr("anotherOwner");
+
+        // when/then
+        vm.expectRevert(
+            abi.encodeWithSignature("TooShortExecutionDelayForRole(uint64,uint32)", Roles.OWNER_ROLE, uint32(1 hours))
+        );
+        vm.prank(owner);
+        accessManager.grantRole(Roles.OWNER_ROLE, anotherOwner, uint32(1 hours));
+    }
+
+    function testShouldNotScheduleRedemptionDelayChangeWhenNotOwner() public {
+        // given
+        _setupTimelockedOwner();
+
+        vm.prank(owner);
+        accessManager.grantRole(Roles.ATOMIST_ROLE, atomist, 0);
+
+        bytes memory data = _setRedemptionDelayCalldata(NEW_REDEMPTION_DELAY);
+
+        // when/then
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "AccessManagerUnauthorizedCall(address,address,bytes4)",
+                atomist,
+                address(plasmaVault),
+                IPlasmaVaultGovernance.setRedemptionDelay.selector
+            )
+        );
+        vm.prank(atomist);
+        accessManager.schedule(address(plasmaVault), data, uint48(block.timestamp + TIMELOCK_24H));
+
+        vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", atomist));
+        vm.prank(atomist);
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(NEW_REDEMPTION_DELAY);
+
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY);
+    }
+
+    function testShouldNotBypassTimelockByCallingAccessManagerDirectly() public {
+        // given - the reviewer's scenario: an owner going straight to the access manager
+        _setupTimelockedOwner();
+
+        bytes memory accessManagerData = abi.encodeWithSelector(
+            IporFusionAccessManager.setRedemptionDelay.selector,
+            NEW_REDEMPTION_DELAY
+        );
+
+        // when/then - the access manager setter is reserved for the vault, for every owner
+        vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", timelockedOwner));
+        vm.prank(timelockedOwner);
+        accessManager.setRedemptionDelay(NEW_REDEMPTION_DELAY);
+
+        vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", owner));
+        vm.prank(owner);
+        accessManager.setRedemptionDelay(NEW_REDEMPTION_DELAY);
+
+        // and - AccessManager cannot schedule its own custom functions at all, which is why the
+        // timelock-capable entry point has to live on the vault
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "AccessManagerUnauthorizedCall(address,address,bytes4)",
+                timelockedOwner,
+                address(accessManager),
+                IporFusionAccessManager.setRedemptionDelay.selector
+            )
+        );
+        vm.prank(timelockedOwner);
+        accessManager.schedule(address(accessManager), accessManagerData, uint48(block.timestamp + TIMELOCK_24H));
+
+        vm.expectRevert(
+            abi.encodeWithSignature(
+                "AccessManagerUnauthorizedCall(address,address,bytes4)",
+                timelockedOwner,
+                address(accessManager),
+                IporFusionAccessManager.setRedemptionDelay.selector
+            )
+        );
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(accessManager), accessManagerData);
+
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY);
+    }
+
+    function testShouldMoveExistingDepositorLockWhenTimelockedChangeExecutes() public {
+        // given - a depositor locked under the initial 1 day delay
+        _setupTimelockedOwner();
+        _whitelistAndDeposit();
+
+        uint256 depositTimestamp = block.timestamp;
+        assertEq(accessManager.getAccountLockTime(depositor), depositTimestamp + INITIAL_REDEMPTION_DELAY);
+
+        bytes memory data = _setRedemptionDelayCalldata(NEW_REDEMPTION_DELAY);
+
+        vm.prank(timelockedOwner);
+        accessManager.schedule(address(plasmaVault), data, uint48(block.timestamp + TIMELOCK_24H));
+
+        // when - the raise executes exactly when the depositor's original lock would have expired
+        vm.warp(depositTimestamp + TIMELOCK_24H);
+        vm.prank(timelockedOwner);
+        accessManager.execute(address(plasmaVault), data);
+
+        // then - the lock is extended, measured from the depositor's own deposit
+        assertEq(accessManager.getAccountLockTime(depositor), depositTimestamp + NEW_REDEMPTION_DELAY);
+
+        uint256 shares = plasmaVault.balanceOf(depositor);
+        uint256 sharesToRedeem = shares / 2;
+
+        vm.expectRevert(abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + NEW_REDEMPTION_DELAY));
+        vm.prank(depositor);
+        plasmaVault.redeem(sharesToRedeem, depositor, depositor);
+
+        // and - releases once the new delay elapses from the original deposit
+        vm.warp(depositTimestamp + NEW_REDEMPTION_DELAY);
+        vm.prank(depositor);
+        plasmaVault.redeem(sharesToRedeem, depositor, depositor);
+
+        assertEq(plasmaVault.balanceOf(depositor), shares - sharesToRedeem);
+    }
+
+    /// @dev Production-like timelock setup: the bootstrapping owner (no delay) raises the minimal execution
+    /// delay for OWNER_ROLE, grants a timelocked owner and a guardian
+    function _setupTimelockedOwner() private {
+        uint64[] memory roleIds = new uint64[](1);
+        roleIds[0] = Roles.OWNER_ROLE;
+        uint256[] memory delays = new uint256[](1);
+        delays[0] = TIMELOCK_24H;
+
+        vm.prank(owner);
+        IPlasmaVaultGovernance(address(plasmaVault)).setMinimalExecutionDelaysForRoles(roleIds, delays);
+
+        vm.prank(owner);
+        accessManager.grantRole(Roles.OWNER_ROLE, timelockedOwner, uint32(TIMELOCK_24H));
+
+        vm.prank(owner);
+        accessManager.grantRole(Roles.GUARDIAN_ROLE, guardian, 0);
+
+        (bool isOwner, uint32 executionDelay) = accessManager.hasRole(Roles.OWNER_ROLE, timelockedOwner);
+        assertTrue(isOwner, "timelocked owner should hold OWNER_ROLE");
+        assertEq(executionDelay, uint32(TIMELOCK_24H), "timelocked owner should have the execution delay");
+    }
+
+    function _whitelistAndDeposit() private {
+        vm.startPrank(owner);
+        accessManager.grantRole(Roles.ATOMIST_ROLE, owner, 0);
+        accessManager.grantRole(Roles.WHITELIST_ROLE, depositor, 0);
+        vm.stopPrank();
+
+        underlyingToken.mint(depositor, DEPOSIT_AMOUNT);
+
+        vm.startPrank(depositor);
+        underlyingToken.approve(address(plasmaVault), DEPOSIT_AMOUNT);
+        plasmaVault.deposit(DEPOSIT_AMOUNT, depositor);
+        vm.stopPrank();
+    }
+
+    function _setRedemptionDelayCalldata(uint256 redemptionDelayInSeconds_) private pure returns (bytes memory) {
+        return abi.encodeWithSelector(IPlasmaVaultGovernance.setRedemptionDelay.selector, redemptionDelayInSeconds_);
+    }
+}

--- a/test/managers/RedemptionDelayUpdateTest.t.sol
+++ b/test/managers/RedemptionDelayUpdateTest.t.sol
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {IporFusionAccessManager} from "../../contracts/managers/access/IporFusionAccessManager.sol";
+import {PlasmaVault} from "../../contracts/vaults/PlasmaVault.sol";
+import {Roles} from "../../contracts/libraries/Roles.sol";
+import {
+    IporFusionAccessManagerInitializerLibV1,
+    DataForInitialization,
+    PlasmaVaultAddress
+} from "../../contracts/vaults/initializers/IporFusionAccessManagerInitializerLibV1.sol";
+import {InitializationData} from "../../contracts/managers/access/IporFusionAccessManagerInitializationLib.sol";
+
+/// @notice Tests for IL-7910 - the redemption delay is mutable after vault creation and the new
+/// value governs every account immediately, existing depositors included (in both directions).
+/// @dev The access manager exposes setRedemptionDelay only to the TECH_PLASMA_VAULT_ROLE - governance changes
+/// the delay through PlasmaVaultGovernance.setRedemptionDelay so the OWNER_ROLE timelock applies (see
+/// RedemptionDelayTimelockTest). Here the PLASMA_VAULT address plays the vault and calls the setter directly.
+contract RedemptionDelayUpdateTest is Test {
+    uint256 private constant INITIAL_REDEMPTION_DELAY = 1 days;
+    uint256 private constant BASE_TIMESTAMP = 1_700_000_000;
+
+    /// @dev Account holding TECH_PLASMA_VAULT_ROLE, simulates the PlasmaVault calling canCallAndUpdate
+    address private constant PLASMA_VAULT = address(0x999);
+
+    address private admin = address(0x1);
+    address private owner = address(0x2);
+    address private atomist = address(0x3);
+    address private userOne = address(0x777);
+    address private userTwo = address(0x888);
+
+    IporFusionAccessManager private accessManager;
+
+    event RedemptionDelayUpdated(uint256 newRedemptionDelayInSeconds);
+    event RedemptionDelayForAccountUpdated(address account, uint256 redemptionDelay);
+
+    function setUp() public {
+        vm.warp(BASE_TIMESTAMP);
+        accessManager = new IporFusionAccessManager(admin, INITIAL_REDEMPTION_DELAY);
+        vm.prank(admin);
+        accessManager.initialize(_generateInitializationData());
+    }
+
+    function testShouldPlasmaVaultSetRedemptionDelayAndEmitEvent() public {
+        //given
+        uint256 newRedemptionDelay = 2 days;
+
+        //when
+        vm.expectEmit(address(accessManager));
+        emit RedemptionDelayUpdated(newRedemptionDelay);
+        _setRedemptionDelay(newRedemptionDelay);
+
+        //then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), newRedemptionDelay);
+    }
+
+    function testShouldPlasmaVaultSetRedemptionDelayToMaximum() public {
+        //given
+        uint256 maxRedemptionDelay = accessManager.MAX_REDEMPTION_DELAY_IN_SECONDS();
+
+        //when
+        _setRedemptionDelay(maxRedemptionDelay);
+
+        //then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), maxRedemptionDelay);
+    }
+
+    function testShouldNotSetRedemptionDelayAboveMaximum() public {
+        //given
+        uint256 tooLongRedemptionDelay = accessManager.MAX_REDEMPTION_DELAY_IN_SECONDS() + 1;
+
+        //when
+        vm.expectRevert(abi.encodeWithSignature("TooLongRedemptionDelay(uint256)", tooLongRedemptionDelay));
+        _setRedemptionDelay(tooLongRedemptionDelay);
+
+        //then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY);
+    }
+
+    function testShouldNotSetRedemptionDelayWhenNotPlasmaVault() public {
+        //given: the owner included - it must go through PlasmaVaultGovernance.setRedemptionDelay (timelock-capable)
+        address[] memory unauthorizedCallers = new address[](4);
+        unauthorizedCallers[0] = owner;
+        unauthorizedCallers[1] = atomist;
+        unauthorizedCallers[2] = admin;
+        unauthorizedCallers[3] = address(0xdead);
+
+        for (uint256 i; i < unauthorizedCallers.length; i++) {
+            //when
+            vm.expectRevert(abi.encodeWithSignature("AccessManagedUnauthorized(address)", unauthorizedCallers[i]));
+            vm.prank(unauthorizedCallers[i]);
+            accessManager.setRedemptionDelay(0);
+        }
+
+        //then
+        assertEq(accessManager.REDEMPTION_DELAY_IN_SECONDS(), INITIAL_REDEMPTION_DELAY);
+    }
+
+    function testShouldConstructorRevertWhenRedemptionDelayAboveMaximum() public {
+        //when
+        vm.expectRevert(abi.encodeWithSignature("TooLongRedemptionDelay(uint256)", 7 days + 1));
+        new IporFusionAccessManager(admin, 7 days + 1);
+    }
+
+    function testShouldEmitRedemptionDelayUpdatedOnConstruction() public {
+        //when
+        vm.expectEmit();
+        emit RedemptionDelayUpdated(3 days);
+        new IporFusionAccessManager(admin, 3 days);
+    }
+
+    function testShouldReleaseExistingDepositorWhenRedemptionDelayLoweredToZero() public {
+        //given: the ticket's worked example - deposit under 1 day delay, the delay is set to 0, withdraw in the same block
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        vm.expectRevert(
+            abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + INITIAL_REDEMPTION_DELAY)
+        );
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+
+        //when
+        _setRedemptionDelay(0);
+
+        //then: all gated operations pass immediately, without any time passing
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+        _withdrawCheck(userOne, PlasmaVault.redeem.selector);
+        _withdrawCheck(userOne, PlasmaVault.transfer.selector);
+        _withdrawCheck(userOne, PlasmaVault.transferFrom.selector);
+    }
+
+    function testShouldLockExistingDepositorWhenRedemptionDelayRaisedFromZero() public {
+        //given: deposit made while the delay is 0 must still record the lock start
+        _setRedemptionDelay(0);
+
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+
+        //when
+        _setRedemptionDelay(1 days);
+
+        //then: the lock is measured from the original deposit
+        vm.expectRevert(abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + 1 days));
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+
+        vm.warp(depositTimestamp + 1 days);
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+    }
+
+    function testShouldExtendLockWhenRedemptionDelayRaisedMidLock() public {
+        //given
+        _setRedemptionDelay(1 hours);
+
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        vm.warp(depositTimestamp + 30 minutes);
+
+        //when
+        _setRedemptionDelay(2 hours);
+
+        //then
+        vm.expectRevert(abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + 2 hours));
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+
+        vm.warp(depositTimestamp + 2 hours);
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+    }
+
+    function testShouldRelockNoLongerLockedAccountWhenRedemptionDelayRaised() public {
+        //given: account deposited under a short delay and its lock has already expired
+        _setRedemptionDelay(1 hours);
+
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        vm.warp(depositTimestamp + 90 minutes);
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+
+        //when
+        _setRedemptionDelay(3 hours);
+
+        //then: the lock returns, measured from the account's own deposit
+        vm.expectRevert(abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + 3 hours));
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+    }
+
+    function testShouldUnlockMidLockWhenRedemptionDelayLoweredBelowElapsedTime() public {
+        //given
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        vm.warp(depositTimestamp + 2 hours);
+
+        //when
+        _setRedemptionDelay(1 hours);
+
+        //then
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+        assertEq(accessManager.getAccountLockTime(userOne), depositTimestamp + 1 hours);
+    }
+
+    function testShouldNeverLockAccountThatNeverDeposited() public {
+        //given
+        _setRedemptionDelay(7 days);
+
+        //then
+        assertEq(accessManager.getAccountLockTime(userTwo), 0);
+        _withdrawCheck(userTwo, PlasmaVault.withdraw.selector);
+        _withdrawCheck(userTwo, PlasmaVault.redeem.selector);
+        _withdrawCheck(userTwo, PlasmaVault.transfer.selector);
+        _withdrawCheck(userTwo, PlasmaVault.transferFrom.selector);
+    }
+
+    function testShouldGateAllFourRestrictedSelectorsWhileLocked() public {
+        //given
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        bytes4[] memory gatedSelectors = new bytes4[](4);
+        gatedSelectors[0] = PlasmaVault.withdraw.selector;
+        gatedSelectors[1] = PlasmaVault.redeem.selector;
+        gatedSelectors[2] = PlasmaVault.transfer.selector;
+        gatedSelectors[3] = PlasmaVault.transferFrom.selector;
+
+        for (uint256 i; i < gatedSelectors.length; i++) {
+            //then
+            vm.expectRevert(
+                abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + INITIAL_REDEMPTION_DELAY)
+            );
+            _withdrawCheck(userOne, gatedSelectors[i]);
+        }
+    }
+
+    function testShouldRecordLockStartForMintAndDepositWithPermit() public {
+        //given
+        uint256 depositTimestamp = block.timestamp;
+
+        //when
+        vm.prank(PLASMA_VAULT);
+        accessManager.canCallAndUpdate(userOne, PLASMA_VAULT, PlasmaVault.mint.selector);
+        vm.prank(PLASMA_VAULT);
+        accessManager.canCallAndUpdate(userTwo, PLASMA_VAULT, PlasmaVault.depositWithPermit.selector);
+
+        //then
+        assertEq(accessManager.getAccountLockTime(userOne), depositTimestamp + INITIAL_REDEMPTION_DELAY);
+        assertEq(accessManager.getAccountLockTime(userTwo), depositTimestamp + INITIAL_REDEMPTION_DELAY);
+    }
+
+    function testShouldResetLockStartOnSubsequentDeposit() public {
+        //given
+        uint256 firstDepositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        vm.warp(firstDepositTimestamp + 12 hours);
+        uint256 secondDepositTimestamp = block.timestamp;
+
+        //when
+        _deposit(userOne);
+
+        //then
+        assertEq(accessManager.getAccountLockTime(userOne), secondDepositTimestamp + INITIAL_REDEMPTION_DELAY);
+
+        vm.warp(firstDepositTimestamp + INITIAL_REDEMPTION_DELAY);
+        vm.expectRevert(
+            abi.encodeWithSignature("AccountIsLocked(uint256)", secondDepositTimestamp + INITIAL_REDEMPTION_DELAY)
+        );
+        _withdrawCheck(userOne, PlasmaVault.withdraw.selector);
+    }
+
+    function testShouldGetAccountLockTimeFollowCurrentRedemptionDelay() public {
+        //given: the frontend scenario - the returned unlock time moves as soon as the delay changes
+        uint256 depositTimestamp = block.timestamp;
+        _deposit(userOne);
+
+        assertEq(accessManager.getAccountLockTime(userOne), depositTimestamp + INITIAL_REDEMPTION_DELAY);
+
+        //when/then
+        _setRedemptionDelay(2 days);
+        assertEq(accessManager.getAccountLockTime(userOne), depositTimestamp + 2 days);
+
+        _setRedemptionDelay(0);
+        assertEq(accessManager.getAccountLockTime(userOne), depositTimestamp);
+    }
+
+    function testShouldEmitRedemptionDelayForAccountUpdatedOnDeposit() public {
+        //when/then
+        vm.expectEmit(address(accessManager));
+        emit RedemptionDelayForAccountUpdated(userOne, block.timestamp + INITIAL_REDEMPTION_DELAY);
+        _deposit(userOne);
+    }
+
+    function testShouldRecordLockStartAndEmitEventWhenRedemptionDelayIsZero() public {
+        //given: no early return on delay == 0 anymore - the deposit is recorded so a later raise applies
+        _setRedemptionDelay(0);
+
+        //when
+        vm.expectEmit(address(accessManager));
+        emit RedemptionDelayForAccountUpdated(userOne, block.timestamp);
+        _deposit(userOne);
+
+        //then
+        assertEq(accessManager.getAccountLockTime(userOne), block.timestamp);
+    }
+
+    /// @dev Plays PlasmaVaultGovernance.setRedemptionDelay - the vault holds TECH_PLASMA_VAULT_ROLE
+    function _setRedemptionDelay(uint256 redemptionDelayInSeconds_) private {
+        vm.prank(PLASMA_VAULT);
+        accessManager.setRedemptionDelay(redemptionDelayInSeconds_);
+    }
+
+    function _deposit(address account_) private {
+        vm.prank(PLASMA_VAULT);
+        accessManager.canCallAndUpdate(account_, PLASMA_VAULT, PlasmaVault.deposit.selector);
+    }
+
+    function _withdrawCheck(address account_, bytes4 selector_) private {
+        vm.prank(PLASMA_VAULT);
+        accessManager.canCallAndUpdate(account_, PLASMA_VAULT, selector_);
+    }
+
+    function _generateInitializationData() private returns (InitializationData memory) {
+        DataForInitialization memory data;
+
+        data.admins = new address[](1);
+        data.admins[0] = admin;
+        data.owners = new address[](1);
+        data.owners[0] = owner;
+        data.atomists = new address[](1);
+        data.atomists[0] = atomist;
+        data.iporDaos = new address[](0);
+        data.alphas = new address[](0);
+        data.whitelist = new address[](0);
+        data.guardians = new address[](0);
+        data.fuseManagers = new address[](0);
+        data.claimRewards = new address[](0);
+        data.transferRewardsManagers = new address[](0);
+        data.configInstantWithdrawalFusesManagers = new address[](0);
+        data.updateMarketsBalancesAccounts = new address[](0);
+        data.updateRewardsBalanceAccounts = new address[](0);
+        data.withdrawManagerRequestFeeManagers = new address[](0);
+        data.withdrawManagerWithdrawFeeManagers = new address[](0);
+        data.priceOracleMiddlewareManagers = new address[](0);
+        data.preHooksManagers = new address[](0);
+
+        /// @dev Dummy non-zero addresses, the initializer requires every manager address to be set
+        address dummyManager = address(0x123);
+        data.plasmaVaultAddress = PlasmaVaultAddress({
+            plasmaVault: PLASMA_VAULT,
+            accessManager: address(accessManager),
+            rewardsClaimManager: dummyManager,
+            withdrawManager: dummyManager,
+            feeManager: dummyManager,
+            contextManager: dummyManager,
+            priceOracleMiddlewareManager: dummyManager
+        });
+
+        return IporFusionAccessManagerInitializerLibV1.generateInitializeIporPlasmaVault(data);
+    }
+}

--- a/test/vaults/PlasmaVaultWithdraw.t.sol
+++ b/test/vaults/PlasmaVaultWithdraw.t.sol
@@ -5,11 +5,20 @@ import {Test} from "forge-std/Test.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {ERC4626} from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-import {PlasmaVault, MarketSubstratesConfig, MarketBalanceFuseConfig, FuseAction, PlasmaVaultInitData} from "../../contracts/vaults/PlasmaVault.sol";
+import {
+    PlasmaVault,
+    MarketSubstratesConfig,
+    MarketBalanceFuseConfig,
+    FuseAction,
+    PlasmaVaultInitData
+} from "../../contracts/vaults/PlasmaVault.sol";
 import {AaveV3SupplyFuse, AaveV3SupplyFuseEnterData} from "../../contracts/fuses/aave_v3/AaveV3SupplyFuse.sol";
 import {AaveV3BalanceFuse} from "../../contracts/fuses/aave_v3/AaveV3BalanceFuse.sol";
 import {CompoundV3BalanceFuse} from "../../contracts/fuses/compound_v3/CompoundV3BalanceFuse.sol";
-import {CompoundV3SupplyFuse, CompoundV3SupplyFuseEnterData} from "../../contracts/fuses/compound_v3/CompoundV3SupplyFuse.sol";
+import {
+    CompoundV3SupplyFuse,
+    CompoundV3SupplyFuseEnterData
+} from "../../contracts/fuses/compound_v3/CompoundV3SupplyFuse.sol";
 import {PlasmaVaultConfigLib} from "../../contracts/libraries/PlasmaVaultConfigLib.sol";
 import {IAavePoolDataProvider} from "../../contracts/fuses/aave_v3/ext/IAavePoolDataProvider.sol";
 import {PriceOracleMiddleware} from "../../contracts/price_oracle/PriceOracleMiddleware.sol";
@@ -444,6 +453,92 @@ contract PlasmaVaultWithdrawTest is Test {
         vm.expectRevert(error);
         vm.prank(userOne);
         plasmaVault.redeem(10e18, userOne, userOne);
+    }
+
+    function testShouldWithdrawImmediatelyWhenOwnerLowersRedemptionDelayToZero() public {
+        //given
+        plasmaVault = _preparePlasmaVaultDai(7 days);
+
+        userOne = address(0x777);
+
+        amount = 100 * 1e18;
+        sharesAmount = 100 * 10 ** plasmaVault.decimals();
+
+        deal(DAI, address(userOne), amount);
+
+        vm.prank(userOne);
+        ERC20(DAI).approve(address(plasmaVault), 3 * amount);
+
+        vm.prank(userOne);
+        plasmaVault.deposit(amount, userOne);
+
+        IporFusionAccessManager accessManager = IporFusionAccessManager(
+            IPlasmaVaultGovernance(address(plasmaVault)).getAccessManagerAddress()
+        );
+
+        bytes memory error = abi.encodeWithSignature("AccountIsLocked(uint256)", block.timestamp + 7 days);
+        vm.expectRevert(error);
+        vm.prank(userOne);
+        plasmaVault.withdraw(amount, userOne, userOne);
+
+        uint256 vaultTotalAssetsBefore = plasmaVault.totalAssets();
+        uint256 userVaultBalanceBefore = plasmaVault.balanceOf(userOne);
+
+        //when - the owner (atomist == address(this) holds OWNER_ROLE) lowers the delay to zero through the
+        //vault's governance entry point, the user withdraws in the same block, without any time passing
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(0);
+
+        vm.prank(userOne);
+        plasmaVault.withdraw(amount, userOne, userOne);
+
+        //then
+        uint256 vaultTotalAssetsAfter = plasmaVault.totalAssets();
+        uint256 userVaultBalanceAfter = plasmaVault.balanceOf(userOne);
+
+        assertEq(vaultTotalAssetsBefore - amount, vaultTotalAssetsAfter, "vaultTotalAssetsBefore - amount");
+        assertEq(userVaultBalanceBefore - sharesAmount, userVaultBalanceAfter, "userVaultBalanceBefore - amount");
+        assertEq(vaultTotalAssetsAfter, 0);
+    }
+
+    function testShouldLockExistingDepositorWhenOwnerRaisesRedemptionDelay() public {
+        //given
+        plasmaVault = _preparePlasmaVaultDai(0);
+
+        userOne = address(0x777);
+
+        amount = 100 * 1e18;
+
+        deal(DAI, address(userOne), amount);
+
+        vm.prank(userOne);
+        ERC20(DAI).approve(address(plasmaVault), 3 * amount);
+
+        uint256 depositTimestamp = block.timestamp;
+
+        vm.prank(userOne);
+        plasmaVault.deposit(amount, userOne);
+
+        IporFusionAccessManager accessManager = IporFusionAccessManager(
+            IPlasmaVaultGovernance(address(plasmaVault)).getAccessManagerAddress()
+        );
+
+        //when - the owner raises the delay (through the vault) after the deposit was made under a zero delay
+        IPlasmaVaultGovernance(address(plasmaVault)).setRedemptionDelay(10 minutes);
+
+        //then - the lock reaches back to the existing deposit, measured from its own deposit time
+        assertEq(accessManager.getAccountLockTime(userOne), depositTimestamp + 10 minutes);
+
+        bytes memory error = abi.encodeWithSignature("AccountIsLocked(uint256)", depositTimestamp + 10 minutes);
+        vm.expectRevert(error);
+        vm.prank(userOne);
+        plasmaVault.withdraw(amount, userOne, userOne);
+
+        //and - unlocks once the delay elapses from the original deposit
+        vm.warp(depositTimestamp + 10 minutes);
+        vm.prank(userOne);
+        plasmaVault.withdraw(amount, userOne, userOne);
+
+        assertEq(plasmaVault.totalAssets(), 0);
     }
 
     function testShouldNotInstantWithdrawBecauseNoShares() public {


### PR DESCRIPTION
- IL-7910: redemption delay mutable after vault creation (PlasmaVaultGovernance.setRedemptionDelay behind OWNER_ROLE timelock, lock start times in new ERC-7201 namespaces)
- IL-7725: PlasmaVaultPauser - one-way emergency pause with per-vault whitelist (Ownable2Step)